### PR TITLE
Timestamp manuscripts with OpenTimestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Generated manuscript output files
 output/index.html
 output/deep-review.pdf
+output/*.ots
 
 # Generated reference files
 references/generated/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci/opentimestamps-client"]
+	path = ci/opentimestamps-client
+	url = https://github.com/opentimestamps/opentimestamps-client.git

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -12,3 +12,4 @@ dependencies:
     - arxiv2bib==1.0.7
     - bibtexparser==0.6.2
     - ghp-import==0.5.5
+    - python-bitcoinlib==0.7.0

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,3 +1,9 @@
+# Generate OpenTimestamps
+python ci/opentimestamps-client/ots stamp \
+  output/index.html \
+  output/deep-review.pdf
+
+# Exit on errors
 set -o errexit
 
 # Configure git

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,10 +1,14 @@
+# Exit on errors
+set -o errexit
+
+# Add commit hash to the README
+envsubst < output/README.md > output/README.md
+
 # Generate OpenTimestamps
 python ci/opentimestamps-client/ots stamp \
   output/index.html \
-  output/deep-review.pdf
-
-# Exit on errors
-set -o errexit
+  output/deep-review.pdf \
+  output/README.md
 
 # Configure git
 git config --global push.default simple

--- a/output/README.md
+++ b/output/README.md
@@ -1,0 +1,18 @@
+# Output directory containing the formatted manuscript
+
+The [`gh-pages`](https://github.com/greenelab/deep-review/tree/gh-pages) branch hosts the contents of this directory at https://greenelab.github.io/deep-review/.
+
+## Files
+
+This directory contains the following files, which are mostly ignored on the `master` branch:
+
++ [`index.html`](index.html) is an HTML manuscript.
++ [`github-pandoc.css`](github-pandoc.css) sets the display style for `index.html`.
++ [`deep-review.pdf`](deep-review.pdf) is a PDF manuscript.
++ `*.ots` files are OpenTimestamps which can be used to verify manuscript existence at or before a given time.
+  [OpenTimestamps](opentimestamps.org) uses the Bitcoin blockchain to attest to file hash existence.
+
+## Source
+
+The manuscripts in this directory were built from
+[`$TRAVIS_COMMIT`](https://github.com/greenelab/deep-review/commit/$TRAVIS_COMMIT).


### PR DESCRIPTION
Uses opentimestamps.org to prove existence of each manuscript version at their corresponding points in time.

Runs for deployment manuscripts only.

Closes https://github.com/greenelab/deep-review/issues/269