### PR TITLE
Fix remaining placeholder references in 04_study.md

### DIFF
--- a/references/tags.tsv
+++ b/references/tags.tsv
@@ -1,5 +1,5 @@
 tag	citation
-Abe doi:10.1101/gr.634603
+Abe	doi:10.1101/gr.634603
 AltaeTran2016_one_shot	arxiv:1611.03199
 Asgari	doi:10.1371/journal.pone.0141287
 blast	doi:10.1016/S0022-2836(05)80360-2
@@ -39,7 +39,7 @@ Hinton2015_dk	arxiv:1503.02531v1
 Hochreiter	doi:10.1093/bioinformatics/btm247
 Hoff	doi:10.1093/nar/gkp327
 Hubara2016_qnn	arxiv:1609.07061
-Karlin  doi:10.1128/jb.179.12.3899-3913.1997
+Karlin	doi:10.1128/jb.179.12.3899-3913.1997
 Kearnes2016_admet	arxiv:1606.08793
 Kearnes2016_graph_conv	doi:10.1007/s10822-016-9938-8
 Keras	url:https://github.com/fchollet/keras
@@ -85,7 +85,7 @@ Stein2010_cloud	doi:10.1186/gb-2010-11-5-207
 Stratnikov	doi:10.1186/2049-2618-1-11
 Su2015_gpu	arxiv:1507.01239
 Sun2016_ensemble	arxiv:1606.00575
-Sutskever arXiv:1409.3215
+Sutskever	arxiv:1409.3215
 Swamidass2009_irv	doi:10.1021/ci8004379
 Tan2014_psb	doi:10.1142/9789814644730_0014
 Tan2015_adage	doi:10.1128/mSystems.00025-15
@@ -97,7 +97,7 @@ Vanhoucke2011_cpu	url:https://research.google.com/pubs/pub37631.html
 Vervier	doi:10.1093/bioinformatics/btv683
 Wallach2015_atom_net	arxiv:1510.02855
 Wang2016_protein_contact	doi:10.1101/073239
-Word2Vec	arXiv:1301.3781
+Word2Vec	arxiv:1301.3781
 wgsquikr	doi:10.1371/journal.pone.0091784
 Yasushi2016_cgbvs_dnn	doi:10.1002/minf.201600045
 yok	doi:10.1186/1471-2105-12-20

--- a/references/tags.tsv
+++ b/references/tags.tsv
@@ -1,5 +1,5 @@
 tag	citation
-Abe	url:http://ci.nii.ac.jp/naid/110006199745
+Abe doi:10.1101/gr.634603
 AltaeTran2016_one_shot	arxiv:1611.03199
 Asgari	doi:10.1371/journal.pone.0141287
 blast	doi:10.1016/S0022-2836(05)80360-2
@@ -39,6 +39,7 @@ Hinton2015_dk	arxiv:1503.02531v1
 Hochreiter	doi:10.1093/bioinformatics/btm247
 Hoff	doi:10.1093/nar/gkp327
 Hubara2016_qnn	arxiv:1609.07061
+Karlin  doi:10.1128/jb.179.12.3899-3913.1997
 Kearnes2016_admet	arxiv:1606.08793
 Kearnes2016_graph_conv	doi:10.1007/s10822-016-9938-8
 Keras	url:https://github.com/fchollet/keras
@@ -84,6 +85,7 @@ Stein2010_cloud	doi:10.1186/gb-2010-11-5-207
 Stratnikov	doi:10.1186/2049-2618-1-11
 Su2015_gpu	arxiv:1507.01239
 Sun2016_ensemble	arxiv:1606.00575
+Sutskever arXiv:1409.3215
 Swamidass2009_irv	doi:10.1021/ci8004379
 Tan2014_psb	doi:10.1142/9789814644730_0014
 Tan2015_adage	doi:10.1128/mSystems.00025-15

--- a/sections/04_study.md
+++ b/sections/04_study.md
@@ -311,16 +311,16 @@ metagenomic analysis.  In the late 2000’s, a plethora of machine learning
 methods were applied to classifying DNA sequencing reads to the thousands of 
 species within a sample.  An important problem is genome assembly from these 
 mixed-organism samples. And to do that, the organisms should be “binned” 
-before assembling.  Binning methods began with many k-mer techniques [refs] 
+before assembling.  Binning methods began with many k-mer techniques [@tag:Karlin] 
 and then delved into other clustering algorithms, such as self-organizing maps 
-(SOM).  Then came the taxonomic classification problem,  with researchers 
+(SOM) [@tag:Abe].  Then came the taxonomic classification problem,  with researchers 
 naturally using BLAST [@tag:blast], followed by other machine learning techniques 
 such as SVMs [@tag:McHardy], naive Bayesian classifiers [@tag:nbc], etc. to classify
 each read.  Then, researchers began to use techniques that could be used to 
 estimate relative abundances of an entire sample, instead of the precise but
 painstakingly slow read-by-read classification.  Relative abundance
-estimators (a.k.a diversity profilers) are MetaPhlan[ref], (WGS)Quikr[ref],
-and some configurations of tools like OneCodex[ref] and LMAT[ref].  While one
+estimators (a.k.a diversity profilers) are MetaPhlan[@tag:Metaphlan], (WGS)Quikr[@tag:wgsquikr],
+and some configurations of tools like OneCodex[@tag:onecodex] and LMAT[@tag:lmat].  While one
 cannot identify which reads were mapped back to an organism using relative
 abundance estimators, they can be useful for faster comparative and other
 downstream analyses.   Newer methods hope to classify reads and estimate
@@ -338,13 +338,13 @@ techniques that bypass the taxonomic classification step altogether [@tag:Ding],
 (sequence composition to phenotype classification).  Also, researchers have
 looked into how feature selection can improve classification [@tag:Liu @tag:Segata],
 and techniques have been proposed that are classifier-independent
-[Ditzler,Ditzler].
+[@tag:Ditzler,@tag:Ditzler2].
 
 So, how have neural networks (NNs) been of use?    Most neural networks are being 
 used for short sequence->taxa/function classification, where there is a lot of data 
 for training (and thus suitable for NNs).  Neural networks have been applied 
 successfully to gene annotation (e.g. Orphelia [@tag:Hoff] and FragGeneScan [@doi:10.1093/nar/gkq747]), 
-which usually has plenty of training examples.  Representations (similar to Word2Vec [ref] in 
+which usually has plenty of training examples.  Representations (similar to Word2Vec [@tag:Word2Vec] in 
 natural language processing) for protein family classification has been introduced and classified 
 with a skip-gram  neural network [@tag:Asgari].  Recurrent neural networks show good performance for 
 homology and protein family identification [@tag:Hochreiter @tag:Sonderby].  Interestingly, 
@@ -373,7 +373,7 @@ Recently, multi-layer, recurrent networks (and convolutional
 networks) have been applied to microbiome genotype-phenotype, with Ditzler et
 al. being the first to associate soil samples with pH level using multi-layer
 perceptrons, deep-belief networks, and recursive neural networks (RNNs) 
-[Ditzler] .  Besides classifying the samples appropriately, Ditzler shows
+[@tag:Ditzler3] .  Besides classifying the samples appropriately, Ditzler shows
 that internal phylogenetic tree nodes inferred by the networks are
 appropriate features representing low/high pH, which can provide additional
 useful information and new features for future metagenomic sample comparison.
@@ -392,11 +392,11 @@ available for training.
 However, because recurrent neural networks are showing success for base-calling (and thus removing the large error in 
 the measurement of a pore's current signal) for the relatively new Oxford Nanopore sequencer [@tag:Boza], there is hope that
 the process of denoising->organism/function classification can be combined into one step in using powerful LSTM's. LSTM's
-are working miracles in raw speech signal->meaning translation [ref], and combining steps in metagenomics are not out of the 
-question.  For example, metagenomic assembly usually requires binning then assembly, but could deep neural nets accomplish
-both tasks in one network? Does functional/taxonomic classification need to be separate processes?  The largest potential
-in deep learning is to learn "everything" in one complex network, with a plethora of labeled (reference) data and unlabeled 
-(microbiome experiments) examples.
+are working miracles in raw speech signal->meaning translation [@tag:Sutskever], and combining steps in metagenomics are not
+out of the question.  For example, metagenomic assembly usually requires binning then assembly, but could deep neural nets
+accomplish both tasks in one network? Does functional/taxonomic classification need to be separate processes?  The largest 
+potential in deep learning is to learn "everything" in one complex network, with a plethora of labeled (reference) data and
+unlabeled (microbiome experiments) examples.
 
 ### Sequencing and variant calling
 

--- a/sections/04_study.md
+++ b/sections/04_study.md
@@ -319,8 +319,8 @@ such as SVMs [@tag:McHardy], naive Bayesian classifiers [@tag:nbc], etc. to clas
 each read.  Then, researchers began to use techniques that could be used to 
 estimate relative abundances of an entire sample, instead of the precise but
 painstakingly slow read-by-read classification.  Relative abundance
-estimators (a.k.a diversity profilers) are MetaPhlan[@tag:Metaphlan], (WGS)Quikr[@tag:wgsquikr],
-and some configurations of tools like OneCodex[@tag:onecodex] and LMAT[@tag:lmat].  While one
+estimators (a.k.a diversity profilers) are MetaPhlan [@tag:Metaphlan], (WGS)Quikr [@tag:wgsquikr],
+and some configurations of tools like OneCodex [@tag:onecodex] and LMAT [@tag:lmat].  While one
 cannot identify which reads were mapped back to an organism using relative
 abundance estimators, they can be useful for faster comparative and other
 downstream analyses.   Newer methods hope to classify reads and estimate
@@ -338,7 +338,7 @@ techniques that bypass the taxonomic classification step altogether [@tag:Ding],
 (sequence composition to phenotype classification).  Also, researchers have
 looked into how feature selection can improve classification [@tag:Liu @tag:Segata],
 and techniques have been proposed that are classifier-independent
-[@tag:Ditzler,@tag:Ditzler2].
+[@tag:Ditzler @tag:Ditzler2].
 
 So, how have neural networks (NNs) been of use?    Most neural networks are being 
 used for short sequence->taxa/function classification, where there is a lot of data 
@@ -373,7 +373,7 @@ Recently, multi-layer, recurrent networks (and convolutional
 networks) have been applied to microbiome genotype-phenotype, with Ditzler et
 al. being the first to associate soil samples with pH level using multi-layer
 perceptrons, deep-belief networks, and recursive neural networks (RNNs) 
-[@tag:Ditzler3] .  Besides classifying the samples appropriately, Ditzler shows
+[@tag:Ditzler3]. Besides classifying the samples appropriately, Ditzler shows
 that internal phylogenetic tree nodes inferred by the networks are
 appropriate features representing low/high pH, which can provide additional
 useful information and new features for future metagenomic sample comparison.


### PR DESCRIPTION
Closes https://github.com/greenelab/deep-review/pull/291. I've taken the relevant commits from https://github.com/greenelab/deep-review/pull/291 and `gailrosen:patch-3`. I resolved the conflicts, squashed the commits, and then fixed remaining issues.

@gailrosen can you reply here with what `@tag:Word2Vec` is referencing? It's not in `tags.tsv`.