### PR TITLE
Use parentheses not brackets for notes

### DIFF
--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -6,10 +6,10 @@ and the Conclusion will provide a short, punchy take home message.
 Points to mention based on discussion thus far that may make the bar for
 conclusions:
 
-* Limitations of data & workarounds [availability impacts on amount, etc]
+* Limitations of data & workarounds (availability impacts on amount, etc)
 * Transferability of features
 * Strong enthusiasm for unsupervised approaches.
-* Right to an explanation [possibly, depends if raised in multiple areas]
+* Right to an explanation (possibly, depends if raised in multiple areas)
 
 ### Author contributions
 


### PR DESCRIPTION
So the build doesn't do "Potentially misformatted references detected"