### PR TITLE
Replace numbered citation_id with 4-byte blake2 hash

### DIFF
--- a/build/citations.py
+++ b/build/citations.py
@@ -1,3 +1,4 @@
+import base64
 import collections
 from hashlib import blake2b
 import pathlib
@@ -108,8 +109,8 @@ def citation_to_metadata(citation, cache={}):
         msg = f'Unsupported citation  source {source} in {citation}'
         raise ValueError(msg)
 
-    blake2_hash = blake2b(standard_citation.encode(), digest_size=4)
-    citation_id = blake2_hash.hexdigest()
+    digest = blake2b(standard_citation.encode(), digest_size=5).digest()
+    citation_id = base64.b32encode(digest).decode()
     result['citation_id'] = citation_id
     if 'citeproc' in result:
         result['citeproc'] = citeproc_passthrough(

--- a/build/citations.py
+++ b/build/citations.py
@@ -1,4 +1,5 @@
 import collections
+from hashlib import blake2b
 import pathlib
 import re
 
@@ -107,7 +108,8 @@ def citation_to_metadata(citation, cache={}):
         msg = f'Unsupported citation  source {source} in {citation}'
         raise ValueError(msg)
 
-    citation_id = f'ref_{len(cache)}'
+    blake2_hash = blake2b(standard_citation.encode(), digest_size=4)
+    citation_id = blake2_hash.hexdigest()
     result['citation_id'] = citation_id
     if 'citeproc' in result:
         result['citeproc'] = citeproc_passthrough(

--- a/build/references.py
+++ b/build/references.py
@@ -106,6 +106,14 @@ if not broken_citations.empty:
     ''')
     raise SystemExit(message)
 
+# Check that no two standard_citations have the same citation_id
+# which could occur due to a hash collision
+collision_df = ref_df[['standard_citation', 'citation_id']].drop_duplicates()
+collision_df = collision_df[collision_df.citation_id.duplicated(keep=False)]
+if not collision_df.empty:
+    print(collision_df)
+    raise SystemExit(f'OMF! Hash collision. Congratulations.')
+
 # Duplicated citations
 print(f'''
 {len(ref_df)} unique citations strings extracted from text


### PR DESCRIPTION
Currently, if you click on a reference in the HTML output, you will get directed to the relevant bibliography item.

For example, click on reference 2 and you will go to https://greenelab.github.io/deep-review/#ref-ref_146. This is confusing since `#ref-ref_146` is an internal citation_id that should not be exposed to the end user. This PR replaces numbered citation IDs with random strings (4-byte blake2 hashes) based on their `standard_citation`.

So for example, `#ref-ref_146` becomes `#ref-0ee8b142`. The purpose is to prevent any confusion.