### PR TITLE
Encode citation_ids using base62

### DIFF
--- a/build/citations.py
+++ b/build/citations.py
@@ -1,9 +1,9 @@
-import base64
 import collections
 from hashlib import blake2b
 import pathlib
 import re
 
+import base62
 import bibtexparser
 
 import metadata
@@ -109,8 +109,8 @@ def citation_to_metadata(citation, cache={}):
         msg = f'Unsupported citation  source {source} in {citation}'
         raise ValueError(msg)
 
-    digest = blake2b(standard_citation.encode(), digest_size=5).digest()
-    citation_id = base64.b32encode(digest).decode()
+    digest = blake2b(standard_citation.encode(), digest_size=6).digest()
+    citation_id = base62.encodebytes(digest)
     result['citation_id'] = citation_id
     if 'citeproc' in result:
         result['citeproc'] = citeproc_passthrough(

--- a/build/citations.py
+++ b/build/citations.py
@@ -138,6 +138,8 @@ citeproc_remove_keys = [
     'ISBN',
     # pandoc-citeproc expected Object not array for archive
     'archive',
+    # failed to parse field event: Could not read as string
+    'event',
 ]
 
 

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - requests=2.13.0
   - pip:
     - arxiv2bib==1.0.7
+    - pybase62==0.2.0
     - bibtexparser==0.6.2
     - ghp-import==0.5.5
     - python-bitcoinlib==0.7.0


### PR DESCRIPTION
Builds off of the merged https://github.com/greenelab/deep-review/pull/298.

Thanks @suminb for adding the ability to base62 encode bytes in https://github.com/suminb/base62/pull/6!

I switched to 6-byte hash... now the probability of collision with 1 million references is 0.18%.

 Builds will still fail until the Crossref API issues are fixed https://github.com/CrossRef/rest-api-doc/issues/194