### PR TITLE
Replace protein structure example in conclusions

### DIFF
--- a/references/tags.tsv
+++ b/references/tags.tsv
@@ -207,7 +207,7 @@ Vera2016_sc_analysis	doi:10.1146/annurev-genet-120215-034854
 Vervier	doi:10.1093/bioinformatics/btv683
 Wallach2015_atom_net	arxiv:1510.02855
 Wang2016_breast_cancer	arxiv:1606.05718
-Wang2016_protein_contact	doi:10.1101/073239
+Wang2016_protein_contact	doi:10.1371/journal.pcbi.1005324
 Wasson1985_clinical	doi:10.1056/NEJM198509263131306
 Word2Vec	arxiv:1301.3781
 wgsquikr	doi:10.1371/journal.pone.0091784

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -42,15 +42,19 @@ molecules from a massive search space would have immense practical value even if
 its overall precision is modest.  In medical imaging, deep learning can point an
 expert to the most challenging cases that require manual review
 [@doi:10.1148/radiol.2017162326], though the risk of false negatives must be
-addressed.
+addressed.  In protein structure prediction, errors in individual
+residue-residue contacts can be tolerated when using the contacts jointly for 3D
+structure modeling.  Improved contact map predictions
+[@tag:Wang2016_protein_contact] have led to notable improvements in fold and 3D
+structure prediction for some of the most challenging proteins, such as membrane
+proteins.
 
 Conversely, the most challenging tasks may be those in which predictions are
 used directly for downstream modeling or decision-making, especially in the
-clinic.  As an example, errors in a predicted protein contact map could be
-amplified if that contact map is used directly for 3D structure prediction.  In
-addition, the stochasticity and complexity of biological systems implies that
-for some problems, for instance, predicting gene regulation in disease, perfect
-accuracy will be unattainable.
+clinic.  As an example, errors in sequence variant calling will be amplified if
+they are used directly for GWAS. In addition, the stochasticity and complexity
+of biological systems implies that for some problems, for instance, predicting
+gene regulation in disease, perfect accuracy will be unattainable.
 
 We are witnessing deep learning models achieving human-level performance across
 a number of biomedical domains, and yet do not believe that biologists and

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -47,7 +47,7 @@ residue-residue contacts can be tolerated when using the contacts jointly for 3D
 structure modeling.  Improved contact map predictions
 [@tag:Wang2016_protein_contact] have led to notable improvements in fold and 3D
 structure prediction for some of the most challenging proteins, such as membrane
-proteins.
+proteins [@arxiv:1704.07207].
 
 Conversely, the most challenging tasks may be those in which predictions are
 used directly for downstream modeling or decision-making, especially in the


### PR DESCRIPTION
Addresses #376.  Two main questions:
- Does the new variant calling and GWAS example work?
- Does the protein structure example belong in this paragraph?  It is an example of a problem where perfect accuracy is not required.  But the other examples in the paragraph pertain to assisting human prioritization and discovery.

@j3xugit I'm interested in your feedback please.  I took only one of your examples from #376 to keep the conclusions concise.