### PR TITLE
Add acknowledgements section and contributors

### DIFF
--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -108,5 +108,6 @@ did participate, are acknowledged at the end of the manuscript.
 
 ### Acknowledgements
 
-We gratefully acknowledge `TODO: names` for their discussion of the manuscript
-and reviewed papers on GitHub. `TODO: add any other acknowledgement categories`
+We gratefully acknowledge Xun Zhu `TODO: names` for their discussion of the
+manuscript and reviewed papers on GitHub. `TODO: add any other acknowledgement
+categories`

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -109,7 +109,7 @@ did participate, are acknowledged at the end of the manuscript.
 ### Acknowledgements
 
 We gratefully acknowledge Christof Angermueller, Kumardeep Chaudhary, Gökcen
-Eraslan, Mikael Huss, Bharath Ramsundar and Xun Zhu
-`TODO: names` for their discussion of the manuscript and reviewed papers on
-GitHub. We would like to thank Zhiyong Lu for revisions to the text that were
-not captured on GitHub.`TODO: add any other acknowledgement categories`
+Eraslan, Michael M. Hoffman, Mikael Huss, Bharath Ramsundar and Xun Zhu for
+their discussion of the manuscript and reviewed papers on GitHub. We would like
+to thank Zhiyong Lu for revisions to the text that were not captured on GitHub.
+`TODO: add any other acknowledgement categories`

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -108,7 +108,8 @@ did participate, are acknowledged at the end of the manuscript.
 
 ### Acknowledgements
 
-We gratefully acknowledge Kumardeep Chaudhary, Gökcen Eraslan, and Xun Zhu
+We gratefully acknowledge Christof Angermueller, Kumardeep Chaudhary, Gökcen
+Eraslan, Mikael Huss, Bharath Ramsundar and Xun Zhu
 `TODO: names` for their discussion of the manuscript and reviewed papers on
 GitHub. We would like to thank Zhiyong Lu for revisions to the text that were
 not captured on GitHub.`TODO: add any other acknowledgement categories`

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -108,6 +108,6 @@ did participate, are acknowledged at the end of the manuscript.
 
 ### Acknowledgements
 
-We gratefully acknowledge Xun Zhu `TODO: names` for their discussion of the
-manuscript and reviewed papers on GitHub. `TODO: add any other acknowledgement
-categories`
+We gratefully acknowledge Kumardeep Chaudhary, Gökcen Eraslan, and Xun Zhu
+`TODO: names` for their discussion of the manuscript and reviewed papers on
+GitHub. `TODO: add any other acknowledgement categories`

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -97,7 +97,7 @@ and biological problems would require expertise from across computational
 biology and medicine. We created an open repository on the GitHub version
 control system [@url:https://github.com/greenelab/deep-review] and engaged with
 numerous authors from papers within and outside of the area. The manuscript was
-drafted via GitHub commits by `TODO #` individuals who met the ICJME standards
+drafted via GitHub commits by 25 individuals who met the ICJME standards
 of authorship. These were individuals who contributed to the review of the
 literature; drafted the manuscript or provided substantial critical revisions;
 approved the final manuscript draft; and agreed to be accountable in all aspects
@@ -111,5 +111,6 @@ did participate, are acknowledged at the end of the manuscript.
 We gratefully acknowledge Christof Angermueller, Kumardeep Chaudhary, Gökcen
 Eraslan, Michael M. Hoffman, Mikael Huss, Bharath Ramsundar and Xun Zhu for
 their discussion of the manuscript and reviewed papers on GitHub. We would like
-to thank Zhiyong Lu for revisions to the text that were not captured on GitHub.
-`TODO: add any other acknowledgement categories`
+to thank Zhiyong Lu for revisions to the text that were not captured on GitHub
+as well as GitHub users aaronsheldon, swamidass, and traversc who contributed
+text but did not formally approve the manuscript.

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -114,3 +114,5 @@ their discussion of the manuscript and reviewed papers on GitHub. We would like
 to thank Zhiyong Lu for revisions to the text that were not captured on GitHub
 as well as GitHub users aaronsheldon, swamidass, and traversc who contributed
 text but did not formally approve the manuscript.
+
+### References

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -91,21 +91,22 @@ that deep learning has transformed biology and medicine.
 
 ### Author contributions
 
-`TODO: not sure if it should go here, but somewhere we should talk about how we
-wrote this thing, since it is still somewhat unconventional to have a review
-written in this manner.` We recognized that writing a review on a rapidly
-developing area in a manner that allowed us to provide a forward-looking
-perspective on diverse approaches and biological problems would require
-expertise from across computational biology and medicine. We created an open
-repository on the GitHub version control system and engaged with numerous
-authors from papers within and outside of the area. Paper review was conducted
-in the open by `#` individuals, and the manuscript was drafted in a series of
-commits from `#` authors. Individuals who met the ICJME standards of authorship
-are included as authors. These were individuals who contributed to the review of
-the literature; drafted the manuscript or provided substantial critical
-revisions; approved the final manuscript draft; and agreed to be accountable in
-all aspects of the work. Individuals who did not contribute in one or more of
-these ways, but who did participate, are acknowledged at the end of the
-manuscript.
+We recognized that writing a review on a rapidly developing area in a manner
+that allowed us to provide a forward-looking perspective on diverse approaches
+and biological problems would require expertise from across computational
+biology and medicine. We created an open repository on the GitHub version
+control system [@url:https://github.com/greenelab/deep-review] and engaged with
+numerous authors from papers within and outside of the area. The manuscript was
+drafted via GitHub commits by `TODO #` individuals who met the ICJME standards
+of authorship. These were individuals who contributed to the review of the
+literature; drafted the manuscript or provided substantial critical revisions;
+approved the final manuscript draft; and agreed to be accountable in all aspects
+of the work. Individuals who did not contribute in all of these ways, but who
+did participate, are acknowledged at the end of the manuscript.
 
 `TODO: update after finalizing discussion in #369`
+
+### Acknowledgements
+
+We gratefully acknowledge `TODO: names` for their discussion of the manuscript
+and reviewed papers on GitHub. `TODO: add any other acknowledgement categories`

--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -110,4 +110,5 @@ did participate, are acknowledged at the end of the manuscript.
 
 We gratefully acknowledge Kumardeep Chaudhary, Gökcen Eraslan, and Xun Zhu
 `TODO: names` for their discussion of the manuscript and reviewed papers on
-GitHub. `TODO: add any other acknowledgement categories`
+GitHub. We would like to thank Zhiyong Lu for revisions to the text that were
+not captured on GitHub.`TODO: add any other acknowledgement categories`


### PR DESCRIPTION
This pull request adds an acknowledgements section for individuals to who helped us discuss the manuscript and issues but have not been included as an author.  I'll start by tagging people I directly interacted with.

If you are on the list below, please let me know how you would like your name to appear in the acknowledgements (or tell me you prefer to be left off):
- @rbharath
- @cangermueller
- @ueser
- @michaelmhoffman
- @hussius
- @gokceneraslan
- @kumardeep27
- @w9


