### PR TITLE
Bibtex: use url not link attribute

### DIFF
--- a/build/citations.py
+++ b/build/citations.py
@@ -185,6 +185,9 @@ def bibtex_passthrough(text, set_id=None):
     entry, = bibdb.entries
     if 'author' in entry:
         entry['author'] = ' and '.join(entry['author'].rstrip(';').split('; '))
+    # Set URL as url rather than link attribute
+    if 'link' in entry and 'url' not in entry:
+        entry['url'] = entry.pop('link')
     if set_id is not None:
         entry['ID'] = set_id
     return bibtexparser.dumps(bibdb)


### PR DESCRIPTION
The eventual goal is to get arxiv references in the bibliography to display their URL. This gets part of the way there.