### PR TITLE
Remove speech recognition TODO

### DIFF
--- a/sections/07_conclusions.md
+++ b/sections/07_conclusions.md
@@ -15,16 +15,15 @@ As an analogy, consider recent progress in conversational speech recognition.
 Since 2009 there have been drastic performance improvements, with error rates
 dropping from more than 20% to less than 6% [@tag:Speech_recognition] and
 finally approaching or exceeding human performance in the past year
-[@arxiv:1610.05256 @arxiv:1703.02136] `TODO: need better source for this error
-trajectory`. The phenomenal improvements on benchmark datasets are undeniable,
-but halving the error rate on these benchmarks did not fundamentally transform
-the domain.  Widespread adoption of conversational speech technologies will
-require not only improvements over baseline methods but truly solving the
-problem, in this case exceeding human-level performance, as well as convincing
-users to embrace the technology [@tag:Speech_recognition].  We see parallels to
-the healthcare domain, where achieving the full potential of deep learning will
-require outstanding predictive performance as well as acceptance and adoption by
-biologists and clinicians.
+[@arxiv:1610.05256 @arxiv:1703.02136]. The phenomenal improvements on benchmark
+datasets are undeniable, but halving the error rate on these benchmarks did not
+fundamentally transform the domain.  Widespread adoption of conversational
+speech technologies will require not only improvements over baseline methods but
+truly solving the problem, in this case exceeding human-level performance, as
+well as convincing users to embrace the technology [@tag:Speech_recognition].
+We see parallels to the healthcare domain, where achieving the full potential of
+deep learning will require outstanding predictive performance as well as
+acceptance and adoption by biologists and clinicians.
 
 Some of the areas we have discussed are closer to surpassing this lofty bar than
 others, generally those that are more similar to the non-biomedical tasks that


### PR DESCRIPTION
I'm removing this TODO because I have not found a better reference for the conversational speech recognition error trajectory.  https://developer.ibm.com/watson/blog/2016/04/28/recent-advances-in-conversational-speech-recognition-2/ is a reasonable article but not much better than what I have.  https://github.com/syhw/wer_are_we has good references but may not be stable.  I was not able to source the Eric Horvitz tweet I considered earlier.