### PR TITLE
Remove duplicate references

### DIFF
--- a/references/tags.tsv
+++ b/references/tags.tsv
@@ -201,7 +201,6 @@ Shaham2016_batch_effects	arxiv:1610.04181
 Shapely	doi:10.1515/9781400881970-018
 Shen2017_medimg_review	doi:10.1146/annurev-bioeng-071516-044442
 Shin2016_cad_tl	doi:10.1109/TMI.2016.2528162
-Shrikumar2016_blackbox	arxiv:1605.01713
 Shrikumar2017_learning	arxiv:1704.02685
 Shrikumar2017_reversecomplement	doi:10.1101/103663
 Simonyan2013_deep	arxiv:1312.6034

--- a/sections/03_categorize.md
+++ b/sections/03_categorize.md
@@ -314,7 +314,7 @@ processes to distinguish gout from leukemia from uric acid sequences. Later work
 showed that unsupervised feature construction of many features via denoising
 autoencoder neural networks could dramatically reduce the number of labeled
 examples required for subsequent supervised analyses
-[@doi:10.1016/j.jbi.2016.10.007 @doi:10.1101/039800]. In addition, it pointed
+[@doi:10.1016/j.jbi.2016.10.007]. In addition, it pointed
 towards learned features being useful for subtyping within a single disease. In
 a concurrent large-scale analysis of EHR data from 700,000 patients, Miotto et
 al. [@doi:10.1038/srep26094] used a deep denoising autoencoder architecture
@@ -540,9 +540,9 @@ parameter which provides a quantification of privacy. Simmons et al.
 [@doi:10.1016/j.cels.2016.04.013] present the ability to perform GWASs in a
 differentially private manner and Abadi et al. [@arxiv:1607.00133] show the
 ability to train deep learning classifiers under the differential privacy
-framework. Federated learning [@arxiv:1602.05629] and secure aggregations
-[@url:http://proceedings.mlr.press/v54/mcmahan17a.html
-@url:https://eprint.iacr.org/2017/281.pdf @tag:Papernot2017_pate] are
+framework. Federated learning
+[@url:http://proceedings.mlr.press/v54/mcmahan17a.html] and secure aggregations
+[@url:https://eprint.iacr.org/2017/281.pdf @tag:Papernot2017_pate] are
 complementary approaches that reinforce differential privacy. Both aim to
 maintain privacy by training deep learning models from decentralized data
 sources such as personal mobile devices without transferring actual training

--- a/sections/04_study.md
+++ b/sections/04_study.md
@@ -237,7 +237,7 @@ useful.
 
 Critically, deep learning can also provide useful biological insights into TF
 binding. Lanchantin et al. [@tag:Lanchantin2016_motif] and Shrikumar et al.
-[@tag:Shrikumar2016_blackbox] developed tools to visualize TF motifs learned
+[@tag:Shrikumar2017_learning] developed tools to visualize TF motifs learned
 from TFBS classification tasks. Alipanahi et al. [@tag:Alipanahi2015_predicting]
 also introduced mutation maps, where they could easily mutate, add, or delete
 base pairs in a sequence and see how the model changed its prediction. This

--- a/sections/06_discussion.md
+++ b/sections/06_discussion.md
@@ -161,7 +161,7 @@ backpropagation-like pass. A classic example of this calculating the gradients
 of the output w.r.t. the input [@tag:Simonyan2013_deep] to compute a "saliency
 map". Bach et al. [@tag:Bach2015_on] proposed a strategy called Layerwise
 Relevance Propagation, which was shown to be equivalent to the elementwise
-product of the gradient and input [@tag:Shrikumar2016_blackbox
+product of the gradient and input [@tag:Shrikumar2017_learning
 @tag:Kindermans2016_investigating]. Several variants of gradients exist which
 differ in their handling of the ReLU nonlinearity. While gradients zero-out the
 importance signal at ReLUs if the input to the ReLU is negative, deconvolutional


### PR DESCRIPTION
I found cases where we had a preprint and published version or a later preprint for the same work.  I removed `doi:10.1101/039800`, `arxiv:1602.05629`, and `Shrikumar2016_blackbox` (which addresses part of #473).