### PR TITLE
Enable templating with jinja2

### DIFF
--- a/build/environment.yml
+++ b/build/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - bioconda::wkhtmltopdf=0.12.3
   - conda-forge::pandoc=1.19.2
+  - jinja2=2.9.6
   - pandas=0.19.2
   - python=3.6.0
   - requests=2.13.0


### PR DESCRIPTION
This PR enables templating, so that including `{{reference_counts.doi}}` will insert the number of DOI references. See https://github.com/greenelab/deep-review/pull/484#issuecomment-302744491