### PR TITLE
Improve duplicate citation text output

### DIFF
--- a/build/references.py
+++ b/build/references.py
@@ -125,8 +125,11 @@ print(f'''
 {ref_df.standard_citation.nunique()} unique citations after standardizations
 '''.strip())
 
-dup_df = ref_df[ref_df.standard_citation.duplicated(keep=False)]
-print(dup_df)
+print(
+    ref_df[ref_df.standard_citation.duplicated(keep=False)]
+    .sort_values('standard_citation')
+    .to_string(index=False, columns=['standard_citation', 'text'])
+)
 
 # Number of distinct references by type
 ref_counts = (


### PR DESCRIPTION
This PR improves the output showing citations that have been cited using multiple in-text strings. The output is now like:

```
451 unique citations strings extracted from text
427 unique citations after standardizations
standard_citation                                text
                 arxiv:1510.02855                   @arxiv:1510.02855
                 arxiv:1510.02855           @tag:Wallach2015_atom_net
                 arxiv:1606.00931                   @arxiv:1606.00931
                 arxiv:1606.00931           @tag:Katzman2016_deepsurv
                 arxiv:1606.05718         @tag:Wang2016_breast_cancer
                 arxiv:1606.05718                   @arxiv:1606.05718
                 arxiv:1608.02158                   @arxiv:1608.02158
                 arxiv:1608.02158             @tag:Ranganath2016_deep
      doi:10.1001/jama.2016.17216                 @tag:Gulshan2016_dt
      doi:10.1001/jama.2016.17216        @doi:10.1001/jama.2016.17216
 doi:10.1007/978-3-642-40763-5_51   @doi:10.1007/978-3-642-40763-5_51
 doi:10.1007/978-3-642-40763-5_51            @tag:Ciresan2013_mitosis
    doi:10.1007/s10278-016-9914-9      @doi:10.1007/s10278-016-9914-9
    doi:10.1007/s10278-016-9914-9       @tag:Rajkomar2017_radiographs
    doi:10.1016/j.jbi.2016.10.007      @doi:10.1016/j.jbi.2016.10.007
    doi:10.1016/j.jbi.2016.10.007   @tag:BeaulieuJones2016_ehr_encode
  doi:10.1016/j.procs.2016.07.014                   @tag:Pratt2016_dr
  doi:10.1016/j.procs.2016.07.014                @tag:Abramoff2016_dr
          doi:10.1038/nature21056            @doi:10.1038/nature21056
          doi:10.1038/nature21056  @tag:Esteva2017_skin_cancer_nature
           doi:10.1038/nmeth.3547              @tag:Zhou2015_deep_sea
           doi:10.1038/nmeth.3547       @tag:Alipanahi2015_predicting
           doi:10.1038/nmeth.4182             @doi:10.1038/nmeth.4182
           doi:10.1038/nmeth.4182  @tag:Buggenthin2017_imaged_lineage
          doi:10.1038/nrg.2015.16           @tag:Gawad2016_singlecell
          doi:10.1038/nrg.2015.16       @tag:Geras2017_multiview_mamm
doi:10.1080/17460441.2016.1201262           @tag:Baskin2015_drug_disc
doi:10.1080/17460441.2016.1201262  @doi:10.1080/17460441.2016.1201262
               doi:10.1101/085118                 @doi:10.1101/085118
               doi:10.1101/085118                  @tag:Pawlowski2016
               doi:10.1101/095786            @tag:Zhu2016_advers_mamm
               doi:10.1101/095786                 @doi:10.1101/095786
               doi:10.1101/095794         @tag:Zhu2016_mult_inst_mamm
               doi:10.1101/095794                 @doi:10.1101/095794
        doi:10.1101/gr.200535.115          @doi:10.1101/gr.200535.115
        doi:10.1101/gr.200535.115              @tag:Kelley2016_basset
    doi:10.1109/bibm.2016.7822593           @tag:Min2016_deepenhancer
    doi:10.1109/bibm.2016.7822593      @doi:10.1109/BIBM.2016.7822593
    doi:10.1109/tcbb.2014.2343960      @doi:10.1109/TCBB.2014.2343960
    doi:10.1109/tcbb.2014.2343960      @doi:10.1109/tcbb.2014.2343960
   doi:10.1142/9789814644730_0014                    @tag:Tan2014_psb
   doi:10.1142/9789814644730_0014     @doi:10.1142/9789814644730_0014
    doi:10.1148/radiol.2017162326      @doi:10.1148/radiol.2017162326
    doi:10.1148/radiol.2017162326        @tag:Lakhani2017_radiography
 doi:10.1371/journal.pcbi.1005324       @tag:Wang2016_protein_contact
 doi:10.1371/journal.pcbi.1005324   @doi:10.1371/journal.pcbi.1005324
        doi:10.15252/msb.20156651          @doi:10.15252/msb.20156651
        doi:10.15252/msb.20156651     @tag:Angermueller2016_dl_review
```

It's not essential that we fix these. Just something to be aware of.