### PR TITLE
Add author list

### DIFF
--- a/author_contact_approve.md
+++ b/author_contact_approve.md
@@ -1,28 +1,28 @@
 | GitHub Handle | Full name | ORCID  | Affiliation(s)  | Email | Approve | Grants to Cite |
 |---------------|-----------|--------|-----------------|-------|---------|----------------|
-| cgreene | Casey S. Greene | 0000-0001-8713-9213 | Department of Systems Pharmacology and Translational Therapeutics. Perelman School of Medicine. University of Pennsylvania. | csgreene@upenn.edu | Yes | Gordon and Betty Moore Foundation GBMF 4552 |
-| j3xugit | Jinbo Xu | 0000-0001-7111-4839 | Toyota Technological Institute at Chicago | jinboxu@gmail.com | Yes | NIH R01GM089753, NSF 1564955 |
-| gailrosen | Gail L. Rosen | 0000-0003-1763-5750 | Ecological and Evolutionary Signal-processing and Informatics Laboratory. Department of Electrical and Computer Engineering. Drexel University | gailr@ece.drexel.edu | Yes | NSF 1245632 |
-| davharris | David J. Harris | 0000-0003-3332-9307 | Wildlife Ecology and Conservation | dave@harris-research.me | Yes | Gordon and Betty Moore Foundation GBMF 4563 |
-| bdo311 | Brian T. Do | 0000-0003-4992-2623 | Harvard Medical School | brian_do@hms.harvard.edu | Yes | NIH T32GM007753 |
-| gwaygenomics | Gregory P. Way | 0000-0002-0503-9348 | Department of Systems Pharmacology and Translational Therapeutics. Perelman School of Medicine. University of Pennsylvania. | gregway@upenn.edu | Yes | |
-| alxndrkalinin | Alexandr A. Kalinin | 0000-0003-4563-3226 | Department of Computational Medicine and Bioinformatics. University of Michigan Medical School. | akalinin@umich.edu | Yes | |
-| agitter | Anthony Gitter | 0000-0002-5324-9833 | Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison. Morgridge Institute for Research | gitter@biostat.wisc.edu | Yes | NIH U54AI117924 |
-| brettbj | Brett K. Beaulieu-Jones | 0000-0002-6700-1468 | Genomics and Computational Biology Graduate Group, Perelman School of Medicine. University of Pennsylvania. | brettbe@upenn.edu | Yes | NIH R01AI116794 |
-| blengerich | Benjamin J. Lengerich | 0000-0001-8690-9554 | Computational Biology Department, School of Computer Science, Carnegie Mellon University | blengeri@cs.cmu.edu | Yes | |
-| agapow | Paul-Michael Agapow | 0000-0003-1126-1479 | Data Science Institute, Imperial College London | p.agapow@imperial.ac.uk | Yes | |
-| enricoferrero | Enrico Ferrero | 0000-0002-8362-100X | Computational Biology and Stats, Target Sciences, GSK | enrico.x.ferrero@gsk.com | Yes | |
-| annecarpenter | Anne E. Carpenter | 0000-0003-1555-8261 | Imaging Platform, Broad Institute of Harvard and MIT | anne@broadinstitute.org | Yes | NIH R01GM089652 |
-| evancofer | Evan M. Cofer | 0000-0003-3877-0433 | Department of Computer Science. Trinity University. | ecofer@princeton.edu | Yes | NSF 1531594 |
-| DaveDeCaprio | Dave DeCaprio | 0000-0001-8931-9461 | ClosedLoop.ai | daved@alum.mit.edu | Yes | |
-| akundaje | Anshul Kundaje | 0000-0003-3084-2287 | Dept. of Genetics, Dept. of Computer Science, Stanford University | akundaje@stanford.edu | Yes | NIH DP2GM123485 |
-| sw1 | Stephen Woloszynek | 0000-0003-0568-298X | Department of Electrical and Computer Engineering, Drexel University | sw424@drexel.edu | Yes | |
-| yfpeng | Yifan Peng | 0000-0001-9309-8331 | National Center for Biotechnology Information, National Library of Medicine, National Institutes of Health | yifan.peng@nih.gov | Yes | National Institutes of Health Intramural Research Program and National Library of Medicine |
-| dhimmel | Daniel S. Himmelstein | 0000-0002-3012-7446 | Department of Systems Pharmacology and Translational Therapeutics. Perelman School of Medicine. University of Pennsylvania. | daniel.himmelstein@gmail.com | Yes | Gordon and Betty Moore Foundation GBMF 4552 |
-| jacklanchantin | Jack Lanchantin | 0000-0003-0811-0944 | University of Virginia. Department of Computer Science | jjl5sw@virginia.edu | Yes | |
-| qiyanjun | Yanjun Qi | 0000-0002-5796-7453 | University of Virginia. Department of Computer Science | yq2h@virginia.edu | Yes | |
-| mrwns | Marwin H. S. Segler | 0000-0001-8008-0546 | Institute of Organic Chemistry, Westfälische Wilhelms-Universität Münster | marwin.segler@uni-muenster.de | Yes | |
-| jisraeli | Johnny Israeli | 0000-0003-1633-5780 | Biophysics Program, Stanford University | jisraeli@stanford.edu | Yes | |
-| xieconnect | Wei Xie | 0000-0002-1871-6846 | Electrical Engineering and Computer Science, Vanderbilt University | wei.xie@vanderbilt.edu | Yes | |
-| AvantiShri | Avanti Shrikumar | 0000-0002-6443-4671 | Stanford University, Department of Computer Science | avanti@stanford.edu | Yes | |
-| laurakwiley | Laura K. Wiley | 0000-0001-6681-9754 | Division of Biomedical Informatics and Personalized Medicine, University of Colorado School of Medicine | laura.wiley@ucdenver.edu | Yes | |
+| cgreene | Casey S. Greene | 0000-0001-8713-9213 | Department of Systems Pharmacology and Translational Therapeutics, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA | csgreene@upenn.edu | Yes | Gordon and Betty Moore Foundation GBMF 4552 |
+| j3xugit | Jinbo Xu | 0000-0001-7111-4839 | Toyota Technological Institute at Chicago, Chicago, IL | jinboxu@gmail.com | Yes | NIH R01GM089753, NSF 1564955 |
+| gailrosen | Gail L. Rosen | 0000-0003-1763-5750 | Ecological and Evolutionary Signal-processing and Informatics Laboratory, Department of Electrical and Computer Engineering, Drexel University, Philadelphia, PA | gailr@ece.drexel.edu | Yes | NSF 1245632 |
+| davharris | David J. Harris | 0000-0003-3332-9307 | Department of Wildlife Ecology and Conservation, University of Florida, Gainesville, FL | dave@harris-research.me | Yes | Gordon and Betty Moore Foundation GBMF 4563 |
+| bdo311 | Brian T. Do | 0000-0003-4992-2623 | Harvard Medical School, Boston, MA | brian_do@hms.harvard.edu | Yes | NIH T32GM007753 |
+| gwaygenomics | Gregory P. Way | 0000-0002-0503-9348 | Department of Systems Pharmacology and Translational Therapeutics, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA | gregway@upenn.edu | Yes | |
+| alxndrkalinin | Alexandr A. Kalinin | 0000-0003-4563-3226 | Department of Computational Medicine and Bioinformatics, University of Michigan Medical School, Ann Arbor, MI | akalinin@umich.edu | Yes | |
+| agitter | Anthony Gitter | 0000-0002-5324-9833 | Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison and Morgridge Institute for Research, Madison, WI | gitter@biostat.wisc.edu | Yes | NIH U54AI117924 |
+| brettbj | Brett K. Beaulieu-Jones | 0000-0002-6700-1468 | Genomics and Computational Biology Graduate Group, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA | brettbe@upenn.edu | Yes | NIH R01AI116794 |
+| blengerich | Benjamin J. Lengerich | 0000-0001-8690-9554 | Computational Biology Department, School of Computer Science, Carnegie Mellon University, Pittsburgh, PA | blengeri@cs.cmu.edu | Yes | |
+| agapow | Paul-Michael Agapow | 0000-0003-1126-1479 | Data Science Institute, Imperial College London, London, United Kingdom | p.agapow@imperial.ac.uk | Yes | |
+| enricoferrero | Enrico Ferrero | 0000-0002-8362-100X | Computational Biology and Stats, Target Sciences, GlaxoSmithKline, Stevenage, United Kingdom | enrico.x.ferrero@gsk.com | Yes | |
+| annecarpenter | Anne E. Carpenter | 0000-0003-1555-8261 | Imaging Platform, Broad Institute of Harvard and MIT, Cambridge, MA | anne@broadinstitute.org | Yes | NIH R01GM089652 |
+| evancofer | Evan M. Cofer | 0000-0003-3877-0433 | Department of Computer Science, Trinity University, San Antonio, TX | ecofer@princeton.edu | Yes | NSF 1531594 |
+| DaveDeCaprio | Dave DeCaprio | 0000-0001-8931-9461 | ClosedLoop.ai, Austin, TX | daved@alum.mit.edu | Yes | |
+| akundaje | Anshul Kundaje | 0000-0003-3084-2287 | Department of Genetics and Department of Computer Science, Stanford University, Stanford, CA | akundaje@stanford.edu | Yes | NIH DP2GM123485 |
+| sw1 | Stephen Woloszynek | 0000-0003-0568-298X | Department of Electrical and Computer Engineering, Drexel University, Philadelphia, PA | sw424@drexel.edu | Yes | |
+| yfpeng | Yifan Peng | 0000-0001-9309-8331 | National Center for Biotechnology Information and National Library of Medicine, National Institutes of Health, Bethesda, MD | yifan.peng@nih.gov | Yes | National Institutes of Health Intramural Research Program and National Library of Medicine |
+| dhimmel | Daniel S. Himmelstein | 0000-0002-3012-7446 | Department of Systems Pharmacology and Translational Therapeutics, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA | daniel.himmelstein@gmail.com | Yes | Gordon and Betty Moore Foundation GBMF 4552 |
+| jacklanchantin | Jack Lanchantin | 0000-0003-0811-0944 | Department of Computer Science, University of Virginia, Charlottesville, VA | jjl5sw@virginia.edu | Yes | |
+| qiyanjun | Yanjun Qi | 0000-0002-5796-7453 | Department of Computer Science, University of Virginia, Charlottesville, VA | yq2h@virginia.edu | Yes | |
+| mrwns | Marwin H. S. Segler | 0000-0001-8008-0546 | Institute of Organic Chemistry, Westfälische Wilhelms-Universität Münster, Münster, Germany | marwin.segler@uni-muenster.de | Yes | |
+| jisraeli | Johnny Israeli | 0000-0003-1633-5780 | Biophysics Program, Stanford University, Stanford, CA | jisraeli@stanford.edu | Yes | |
+| xieconnect | Wei Xie | 0000-0002-1871-6846 | Electrical Engineering and Computer Science, Vanderbilt University, Nashville, TN | wei.xie@vanderbilt.edu | Yes | |
+| AvantiShri | Avanti Shrikumar | 0000-0002-6443-4671 | Department of Computer Science, Stanford University, Stanford, CA | avanti@stanford.edu | Yes | |
+| laurakwiley | Laura K. Wiley | 0000-0001-6681-9754 | Division of Biomedical Informatics and Personalized Medicine, University of Colorado School of Medicine, Aurora, CO | laura.wiley@ucdenver.edu | Yes | |

--- a/authors/author-order.ipynb
+++ b/authors/author-order.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Order deep-review authors\n",
+    "Create multiple types of equal contributions.  Within a [contribution class](https://github.com/greenelab/deep-review/pull/508#issue-231012181), authors are randomly ordered.  Once an initial ordering has been made, any new authors (for example, authors added during revisions) are placed at the end of the ordered list for the appropriate contribution class in a random order.  A [pre-registered seed](https://github.com/greenelab/deep-review/issues/369#issuecomment-302125051) makes the ordering deterministic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Function to print the ordered contribution classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def print_authors(contrib_map):\n",
+    "    authors = []\n",
+    "    for contrib_type in sorted(contrib_map.keys()):\n",
+    "        authors.extend(contrib_map[contrib_type])\n",
+    "    print('{}\\n'.format(', '.join(authors)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Order and print the contribution classes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Before ordering\n",
+      "@agapow, @alxndrkalinin, @bdo311, @brettbj, @dhimmel, @enricoferrero, @gwaygenomics, @traversc, @AnneCarpenter, @AvantiShri, @blengerich, @evancofer, @gailrosen, @j3xugit, @jacklanchantin, @jisraeli, @sw1, @XieConnect, @akundaje, @DaveDeCaprio, @davharris, @laurakwiley, @mrwns, @qiyanjun, @yfpeng, @agitter, @cgreene\n",
+      "\n",
+      "After initial ordering\n",
+      "@traversc, @dhimmel, @brettbj, @alxndrkalinin, @bdo311, @gwaygenomics, @enricoferrero, @agapow, @XieConnect, @gailrosen, @blengerich, @jisraeli, @jacklanchantin, @sw1, @AnneCarpenter, @AvantiShri, @j3xugit, @evancofer, @davharris, @DaveDeCaprio, @qiyanjun, @akundaje, @yfpeng, @laurakwiley, @mrwns, @agitter, @cgreene\n",
+      "\n",
+      "After adding authors (not yet applicable)\n",
+      "@traversc, @dhimmel, @brettbj, @alxndrkalinin, @bdo311, @gwaygenomics, @enricoferrero, @agapow, @XieConnect, @gailrosen, @blengerich, @jisraeli, @jacklanchantin, @sw1, @AnneCarpenter, @AvantiShri, @j3xugit, @evancofer, @davharris, @DaveDeCaprio, @qiyanjun, @akundaje, @yfpeng, @laurakwiley, @mrwns, @agitter, @cgreene\n",
+      "\n",
+      "27 total authors\n"
+     ]
+    }
+   ],
+   "source": [
+    "import random\n",
+    "from collections import defaultdict\n",
+    "from functools import reduce\n",
+    "\n",
+    "# see above for how the seed was determined in advance\n",
+    "random.seed(0x06edef4bee392038b3e0403b0fa4208e11ddcc5d)\n",
+    "\n",
+    "# map contribution types to lists of original authors\n",
+    "contrib_map = dict()\n",
+    "# lead contribution\n",
+    "contrib_map['01_lead'] =\\\n",
+    "    ['@agapow', '@alxndrkalinin', '@bdo311', '@brettbj', '@dhimmel', '@enricoferrero', '@gwaygenomics', '@traversc']\n",
+    "# default contribution\n",
+    "contrib_map['02_default'] =\\\n",
+    "    ['@AnneCarpenter', '@AvantiShri', '@blengerich', '@evancofer', '@gailrosen', '@j3xugit', '@jacklanchantin', '@jisraeli', '@sw1', '@XieConnect']\n",
+    "# other contribution\n",
+    "contrib_map['03_other'] =\\\n",
+    "    ['@akundaje', '@DaveDeCaprio', '@davharris', '@laurakwiley', '@mrwns', '@qiyanjun', '@yfpeng']\n",
+    "# corresponding authors\n",
+    "contrib_map['04_corresponding'] = ['@agitter', '@cgreene']\n",
+    "\n",
+    "print('Before ordering')\n",
+    "print_authors(contrib_map)\n",
+    "\n",
+    "contrib_types = sorted(contrib_map.keys())\n",
+    "\n",
+    "# order all initial authors\n",
+    "for contrib_type in contrib_types:\n",
+    "    random.shuffle(contrib_map[contrib_type])\n",
+    "\n",
+    "print('After initial ordering')\n",
+    "print_authors(contrib_map)\n",
+    "\n",
+    "# new authors after revisions\n",
+    "new_contrib_map = defaultdict(list)\n",
+    "\n",
+    "# add new authors to the end of the existing category in a random order\n",
+    "for contrib_type in contrib_types:\n",
+    "    random.shuffle(new_contrib_map[contrib_type])\n",
+    "    contrib_map[contrib_type].extend(new_contrib_map[contrib_type])\n",
+    "\n",
+    "print('After adding authors (not yet applicable)')\n",
+    "print_authors(contrib_map)\n",
+    "\n",
+    "# total number of authors\n",
+    "print('{} total authors'.format(reduce((lambda x,y: x+y), map(len, contrib_map.values()))))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/sections/00_title_authors.md
+++ b/sections/00_title_authors.md
@@ -1,5 +1,54 @@
 # Opportunities and obstacles for deep learning in biology and medicine
 
-*Randomly-ordered authors here* <sup>*</sup>
+Travers Ching<sup>1,*</sup>, Daniel S. Himmelstein<sup>2</sup>, Brett K.
+Beaulieu-Jones<sup>3</sup>, Alexandr A. Kalinin<sup>4</sup>, Brian T.
+Do<sup>5</sup>, Gregory P. Way<sup>2</sup>, Enrico Ferrero<sup>6</sup>,
+Paul-Michael Agapow<sup>7</sup>, Wei Xie<sup>8</sup>, Gail L. Rosen<sup>9</sup>,
+Benjamin J. Lengerich<sup>10</sup>, Johnny Israeli<sup>11</sup>, Jack
+Lanchantin<sup>12</sup>, Stephen Woloszynek<sup>13</sup>, Anne E.
+Carpenter<sup>14</sup>, Avanti Shrikumar<sup>15</sup>, Jinbo Xu<sup>16</sup>,
+Evan M. Cofer<sup>17</sup>, David J. Harris<sup>18</sup>, Dave
+DeCaprio<sup>19</sup>, Yanjun Qi<sup>12</sup>, Anshul Kundaje<sup>20</sup>,
+Yifan Peng<sup>21</sup>, Laura K. Wiley<sup>22</sup>, Marwin H.S.
+Segler<sup>23</sup>, Anthony Gitter<sup>24,+</sup>, Casey S.
+Greene<sup>2,+</sup>
 
 <sup>*</sup> Author order was determined with a randomized algorithm
+
+<sup>+</sup> To whom correspondence should be addressed: gitter@biostat.wisc.edu
+(A.G.) and csgreene@upenn.edu (C.S.G.)
+
+<sup>1</sup>Molecular Biosciences and Bioengineering Graduate Program,
+University of Hawaii at Manoa, Honolulu, HI; <sup>2</sup>Department of Systems
+Pharmacology and Translational Therapeutics, Perelman School of Medicine,
+University of Pennsylvania, Philadelphia, PA; <sup>3</sup>Genomics and
+Computational Biology Graduate Group, Perelman School of Medicine, University of
+Pennsylvania, Philadelphia, PA; <sup>4</sup>Department of Computational Medicine
+and Bioinformatics, University of Michigan Medical School, Ann Arbor, MI;
+<sup>5</sup>Harvard Medical School, Boston, MA; <sup>6</sup>Computational
+Biology and Stats, Target Sciences, GlaxoSmithKline, Stevenage, United Kingdom;
+<sup>7</sup>Data Science Institute, Imperial College London, London, United
+Kingdom; <sup>8</sup>Electrical Engineering and Computer Science, Vanderbilt
+University, Nashville, TN; <sup>9</sup>Ecological and Evolutionary
+Signal-processing and Informatics Laboratory, Department of Electrical and
+Computer Engineering, Drexel University, Philadelphia, PA;
+<sup>10</sup>Computational Biology Department, School of Computer Science,
+Carnegie Mellon University, Pittsburgh, PA; <sup>11</sup>Biophysics Program,
+Stanford University, Stanford, CA; <sup>12</sup>Department of Computer Science,
+University of Virginia, Charlottesville, VA; <sup>13</sup>Department of
+Electrical and Computer Engineering, Drexel University, Philadelphia, PA;
+<sup>14</sup>Imaging Platform, Broad Institute of Harvard and MIT, Cambridge,
+MA; <sup>15</sup>Department of Computer Science, Stanford University, Stanford,
+CA; <sup>16</sup>Toyota Technological Institute at Chicago, Chicago, IL;
+<sup>17</sup>Department of Computer Science, Trinity University, San Antonio,
+TX; <sup>18</sup>Department of Wildlife Ecology and Conservation, University of
+Florida, Gainesville, FL; <sup>19</sup>ClosedLoop.ai, Austin, TX;
+<sup>20</sup>Department of Genetics and Department of Computer Science, Stanford
+University, Stanford, CA; <sup>21</sup>National Center for Biotechnology
+Information and National Library of Medicine, National Institutes of Health,
+Bethesda, MD; <sup>22</sup>Division of Biomedical Informatics and Personalized
+Medicine, University of Colorado School of Medicine, Aurora, CO;
+<sup>23</sup>Institute of Organic Chemistry, Westfälische Wilhelms-Universität
+Münster, Münster, Germany; <sup>24</sup>Department of Biostatistics and Medical
+Informatics, University of Wisconsin-Madison and Morgridge Institute for
+Research, Madison, WI

--- a/sections/00_title_authors.md
+++ b/sections/00_title_authors.md
@@ -1,5 +1,5 @@
 # Opportunities and obstacles for deep learning in biology and medicine
 
-For preliminary authorship information, see the
-[contributors](https://github.com/greenelab/deep-review/graphs/contributors) on
-GitHub.
+*Randomly-ordered authors here* <sup>*</sup>
+
+<sup>*</sup> Author order was determined with a randomized algorithm

--- a/sections/08_methods.md
+++ b/sections/08_methods.md
@@ -36,8 +36,7 @@ These were individuals who contributed to the review of the literature;
 drafted the manuscript or provided substantial critical revisions;
 approved the final manuscript draft; and agreed to be accountable in all aspects of the work.
 Individuals who did not contribute in all of these ways, but who did participate, are acknowledged below.
-
-`TODO: update after finalizing discussion in #369`
+We grouped authors into four classes of approximately equal contributions and randomly ordered authors within each contribution class.
 
 ### Acknowledgements
 

--- a/sections/08_methods.md
+++ b/sections/08_methods.md
@@ -36,7 +36,11 @@ These were individuals who contributed to the review of the literature;
 drafted the manuscript or provided substantial critical revisions;
 approved the final manuscript draft; and agreed to be accountable in all aspects of the work.
 Individuals who did not contribute in all of these ways, but who did participate, are acknowledged below.
-We grouped authors into four classes of approximately equal contributions and randomly ordered authors within each contribution class.
+We grouped authors into the following four classes of approximately equal contributions and randomly ordered authors within each contribution class.
+Drafted multiple sub-sections along with extensive editing, pull request reviews, or discussion: A.A.K., B.K.B., B.T.D., D.S.H., E.F., G.P.W., P.A., T.C.
+Drafted one or more sub-sections: A.E.C., A.S., B.J.L., E.M.C., G.L.R., J.I., J.L., J.X., S.W., W.X.
+Revised specific sub-sections or supervised drafting one or more sub-sections: A.K., D.D., D.J.H., L.K.W., M.H.S.S., Y.P., Y.Q.
+Drafted sub-sections, edited the manuscript, reviewed pull requests, and coordinated co-authors: A.G., C.S.G..
 
 ### Acknowledgements
 


### PR DESCRIPTION
My initial commit explains the author order discussed in #369.  Today, I will run the randomized algorithm that arbitrarily sorts authors within each contribution class.  It will closely resemble [my proof-of-concept](https://github.com/agitter/deep-review/blob/author-order/authors/author_order_demo.ipynb) and use the [pre-determined seed](https://github.com/greenelab/deep-review/issues/369#issuecomment-302125051).

We have four types of contributions (these category names won't appear anywhere):

- **Lead**: drafted multiple sub-sections as well as extensive editing, pull request reviews, or discussions
  - @agapow
  - @alxndrkalinin
  - @bdo311
  - @brettbj
  - @dhimmel
  - @enricoferrero
  - @gwaygenomics
  - @traversc

- **Default**: drafted 1-2 sub-sections
  - @annecarpenter
  - @AvantiShri
  - @blengerich
  - @evancofer
  - @gailrosen
  - @j3xugit
  - @jacklanchantin
  - @jisraeli
  - @sw1
  - @xieconnect

- **Other**: polished specific sub-sections, supervised drafting a sub-section, etc.
  - @akundaje
  - @DaveDeCaprio
  - @davharris
  - @laurakwiley
  - @mrwns
  - @qiyanjun
  - @yfpeng

- **Corresponding**
  - @agitter
  - @cgreene

User names are sorted here, but the initial order won't matter once we randomize.