### PR TITLE
Update build notes

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -12,3 +12,4 @@ conda env create --file environment.yml
 ```
 
 Activate with `source activate deepreview`.
+Currently, the environment requires Linux.

--- a/build/README.md
+++ b/build/README.md
@@ -5,10 +5,10 @@
 
 ## Environment
 
-Install the [conda](https://conda.io) environment specified in [`environment.yml`](../environment.yml) by running:
+Install the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running:
 
 ```sh
 conda env create --file environment.yml
 ```
 
-Activate with `source activate deep-review`.
+Activate with `source activate deepreview`.


### PR DESCRIPTION
Should I also add a line to the build readme stating that the environment does not currently support Windows?  In Windows, `conda env create --file environment.yml`  gives

```
NoPackagesFoundError: Package missing in current win-64 channels:
  - wkhtmltopdf 0.12.3*
```