### PR TITLE
LSTM now defined; remove extraneous definition

### DIFF
--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -308,8 +308,8 @@ improved by up to 15% when compared to other methods. Choi et
 al. [@arxiv:1511.05942] attempted to model the longitudinal structure of EHRs
 with a RNN to predict future diagnosis and medication prescriptions on a cohort
 of 260,000 patients followed for 8 years (Doctor AI). Pham et al.
-[@arxiv:1602.00357] built upon this concept by utilising a RNN with a long 
-short-term memory (LSTM) architecture enabling explicit modelling of patient
+[@arxiv:1602.00357] built upon this concept by utilising a RNN with a LSTM
+architecture enabling explicit modelling of patient
 trajectories through the use of memory cells. The method, DeepCare, performed
 better than shallow models or plain RNN when tested on two independent cohorts
 for its ability to predict disease progression, intervention recommendation and


### PR DESCRIPTION
@SiminaB defined LSTM in the glossary table from #588 . I remembered that it was redefined here. This is a quick fix to get back to the intended "define in one place" mantra.