### PR TITLE
Condense NLP section

### DIFF
--- a/content/02.intro.md
+++ b/content/02.intro.md
@@ -27,13 +27,13 @@ Deep learning approaches grew from research in neural networks, which were first
 for how our brains process information. The history of neural networks is
 interesting in its own right [@doi:10.1103/RevModPhys.34.135]. In neural
 networks, inputs are fed into a hidden layer, which feeds into one or more
-hidden layers, which eventually link to an output layer. 
+hidden layers, which eventually link to an output layer.
 A layer consists of a set of nodes, usually called "features" or "units,"
 which are connected via edges to the immediately earlier and the
 immediately deeper layers.
 The nodes of the input layer generally consist of the variables being measured in the dataset
 of interest -- for example, each node could represent the intensity value of a specific
-pixel in an image processing application or a gene expression value in a transcriptomics 
+pixel in an image processing application or a gene expression value in a transcriptomics
 experiment.
 The neural networks
 used for deep learning have multiple hidden layers. Each layer essentially
@@ -41,23 +41,23 @@ performs feature construction for the layers before it. The training process
 used often allows layers deeper in the network to contribute to the refinement
 of earlier layers. For this reason, these algorithms can automatically engineer
 features that are suitable for many tasks and customize those features for one
-or more specific tasks. 
+or more specific tasks.
 
 Deep learning does many of the same things as more
 familiar machine learning approaches. In particular, deep learning approaches can be used both in *supervised*
 applications -- where the goal is to accurately predict one or more labels or outcomes associated with each
-data point -- in the place of regression approaches, as well as in *unsupervised*, or "exploratory" applications -- 
+data point -- in the place of regression approaches, as well as in *unsupervised*, or "exploratory" applications --
 where the goal is to summarize, explain, or
 identify interesting patterns in a data set -- as a form of clustering.
 Deep learning methods may in fact combine both of
 these steps. When sufficient data are available and labeled, these methods construct
 features tuned to a specific problem and combine those features into a
 predictor.
-In fact, if the dataset is "labeled" with binary classes, a simple neural network 
+In fact, if the dataset is "labeled" with binary classes, a simple neural network
 with no hidden layers and no cycles between units is equivalent to logistic regression
 if the output layer is a sigmoid (logistic) function of the input layer.
 Similarly, for continuous outcomes, linear regression can be seen as a simple neural network.
-Thus, in some ways, supervised deep learning approaches can be seen as a generalization of regression 
+Thus, in some ways, supervised deep learning approaches can be seen as a generalization of regression
 models that allow for greater flexibility.
 Recently, hardware improvements and very
 large training datasets have allowed these deep learning techniques to surpass
@@ -89,13 +89,13 @@ covers these in detail [@url:http://www.deeplearningbook.org/]. Finally, the
 larger datasets now available are also sufficient for fitting the many
 parameters that exist for deep neural networks. The convergence of these factors
 currently makes deep learning extremely adaptable and capable of addressing the
-nuanced differences of each domain to which it is applied. 
+nuanced differences of each domain to which it is applied.
 
 | Term | Definition |
 |----------------------------|-------------------------------------------------------------------------------------------|
 | Neural network  (NN) | Machine-learning approach where inputs are fed into one or more hidden layers, producing an outer layer |
-| Deep learning (DL) approach | NN with multiple hidden layers | 
-| Supervised learning | Machine-learning approaches with goal of prediction of labels or outcomes | 
+| Deep learning (DL) approach | NN with multiple hidden layers |
+| Supervised learning | Machine-learning approaches with goal of prediction of labels or outcomes |
 | Unsupervised learning | Machine-learning approaches with goal of data summarization or pattern identification |
 | Convolutional neural network (CNN) | NN used for grid data -- such as images or equally-spaced time points - that considers convolutions instead of linear transformations, leading to increased sparsity and thus improved efficiency |
 | Feed-forward neural network (FFNN) | NN that does not have cycles between nodes in the same layer |
@@ -112,7 +112,7 @@ nuanced differences of each domain to which it is applied.
 Table: Glossary.
 {#tbl:glossary}
 
-While deep learning shows increased flexibility over other machine learning approaches, as 
+While deep learning shows increased flexibility over other machine learning approaches, as
 seen in the remainder of this review, it requires large training sets in order to fit
 the hidden layers, as well as accurate labels for the supervised learning applications.
 For these reasons, deep learning has recently become popular in some areas of biology and medicine, while having lower adoption in other areas.
@@ -138,7 +138,7 @@ a Strategic Inflection Point in the practice of biology or medicine.
 There are already a number of reviews focused on applications of deep learning
 in biology [@doi:10.1038/nbt.3313; @doi:10.1021/acs.molpharmaceut.5b00982;
 @doi:10.15252/msb.20156651; @doi:10.1093/bib/bbw068;
-@doi:10.3109/10409238.2015.1135868], healthcare [@doi:10.1093/bib/bbx044], and
+@doi:10.3109/10409238.2015.1135868], healthcare [@doi:10.1093/bib/bbx044; @tag:Litjens2017_medimage_survey], and
 drug discovery [@doi:10.1002/minf.201501008; @doi:10.1002/jcc.24764;
 @tag:PerezSianes2016_screening; @tag:Baskin2015_drug_disc].  Under our guiding
 question, we sought to highlight cases where deep learning enabled researchers

--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -233,22 +233,15 @@ better-informed decisions for patient treatment and care.
 
 ### Text applications in healthcare
 
-Due to the rapid growth of scholarly publications and electronic medical/health records, biomedical text mining has become increasingly important in recent years.
+Due to the rapid growth of scholarly publications and EHRs, biomedical text mining has become increasingly important in recent years.
 The main tasks in biological and clinical text mining include, but are not limited to, named entity recognition, relation/event extraction, and information retrieval (Figure @fig:biotm).
+Deep learning is appealing in this domain because of its competitive performance versus traditional methods and ability to overcome challenges in feature engineering.
+Relevant applications can be stratified by the application domain (biomedical literature vs. clinical notes) and the actual task (e.g. concept or relation extraction).
 
-![Deep learning applications, tasks and models based on NLP perspectives.](images/biotm.png){#fig:biotm width="100%"}
+![Deep learning applications, tasks, and models based on NLP perspectives.](images/biotm.png){#fig:biotm width="100%"}
 
-Machine learning is widely used in many of aforementioned tasks where engineering the optimal set of features is a must.
-However it is often difficult to know what features should be extracted, even with domain knowledge.
-Deep learning addresses this challenge by enabling "computers to build complex
-concepts out of simpler ones [@tag:goodfellow2016deep]".
-Moreover, deep learning has shown competitive performance compared to traditional ML methods.
-As a result, we have observed growing interests of using deep learning in biomedical text mining applications in recent years.
-In this section, we summarize recent studies in text mining with various deep learning methods.
-We categorize the body of work by the application domain/text genre (biomedical literature vs. clinical notes) and by the actual task (e.g. concept or relation extraction).
-
-In biomedical text mining, named entity recognition (NER) is a task of identifying text spans that refer to a biological concept of a specific class, such as disease or chemical, in a controlled vocabulary or ontology.
-NER is of importance as it is often needed as a first step in many complex text mining systems.
+Named entity recognition (NER) is a task of identifying text spans that refer to a biological concept of a specific class, such as disease or chemical, in a controlled vocabulary or ontology.
+NER is often needed as a first step in many complex text mining systems.
 The current state-of-the-art methods typically reformulate the task as a sequence labeling problem and use conditional random fields [@doi:10.1093/bioinformatics/btw343; @doi:10.1093/bioinformatics/btt156; @doi:10.1093/bioinformatics/btt474].
 In recent years, word embeddings that contain rich latent semantic information of words have been widely used to improve the NER performance.
 Liu et al. studied the effect of word embeddings on drug name recognition and compared them with traditional semantic features [@doi:10.3390/info6040848].
@@ -256,36 +249,37 @@ Tang et al. investigated word embeddings in gene, DNA, and cell line mention det
 Moreover, Wu et al. examined the use of neural word embeddings for clinical abbreviation disambiguation [@doi:10.18653/v1/w15-3822].
 Liu et al. exploited task-oriented resources to learn word embeddings for clinical abbreviation expansion [@doi:10.18653/v1/w15-3810].
 
-Relation extraction is a task of detecting and classifying semantic relationship between entities from the literature.
+Relation extraction involves detecting and classifying semantic relationships between entities from the literature.
 At present, kernel methods or feature-based approaches are commonly applied [@doi:10.1371/journal.pcbi.1000837; @doi:10.1186/s13321-016-0165-z; @doi:10.1093/bioinformatics/btp602].
-There are several proposals of using deep learning in the biomedical relation tasks because it can relieve the feature sparsity and engineering problems.
-Some studies focused on jointly extracting biomedical entities as well as their relations simultaneously [@tag:li2016joint; @doi:10.1186/s12859-017-1609-9], while others applied deep learning on relation classification with given entities.
-For example, Peng and Lu proposed a multichannel dependency-based CNN and Hua and Quan proposed a shortest path based CNN for the sentence-based protein-protein extraction task [@doi:10.18653/v1/w17-2304; @doi:10.1155/2016/8479587; @doi:10.1155/2016/1850404].
+Deep learning can relieve the feature sparsity and engineering problems.
+Some studies focused on jointly extracting biomedical entities and relations simultaneously [@tag:li2016joint; @doi:10.1186/s12859-017-1609-9], while others applied deep learning on relation classification given the relevant entities.
+For example, both multichannel dependency-based CNNs [@doi:10.18653/v1/w17-2304] and shortest path-based CNNs [@doi:10.1155/2016/8479587; @doi:10.1155/2016/1850404] are well-suited for sentence-based protein-protein extraction.
 Jiang et al. proposed a biomedical domain-specific word embedding model to reduce the manual labor of designing semantic representation for the same task [@doi:10.1504/IJDMB.2016.074878].
-Gu et al. employed a maximum entropy model and a CNN model for chemical-induced disease relation extraction at inter- and intra-sentence level, respectively [@doi:10.1093/database/bax024].
-For drug-drug interaction, Zhao et al. used a CNN that employs word embeddings with the syntactic information of a sentence as well as features of POS tags and dependency trees [@doi:10.1093/bioinformatics/btw486].
-Masaki et al. experimented with an attention CNN, and Yi et al. a recurrent neural network model (RNN) model with multiple attention layers [@doi:10.18653/v1/w17-2302; @arxiv:1705.03261].
-In both cases, it is a single model with attention mechanism, which allows the decoder to "attend" to different parts of the source sentence. As a result, it does not require dependency parsing or training multiple models. 
-Both attention CNN and RNN have comparable results, but the CNN model has an advantage in that it can be easily computed in parallel, hence making it faster with recent Graphical Processing Units (GPUs).
+Gu et al. employed a maximum entropy model and a CNN model for chemical-induced disease relation extraction at the inter- and intra-sentence level, respectively [@doi:10.1093/database/bax024].
+For drug-drug interaction, Zhao et al. used a CNN that employs word embeddings with the syntactic information of a sentence as well as features of  part-of-speech tags and dependency trees [@doi:10.1093/bioinformatics/btw486].
+Asada et al. experimented with an attention CNN [@doi:10.18653/v1/w17-2302], and Yi et al. a RNN model with multiple attention layers [@arxiv:1705.03261].
+In both cases, it is a single model with attention mechanism, which allows the decoder to focus on different parts of the source sentence.
+As a result, it does not require dependency parsing or training multiple models.
+Both attention CNN and RNN have comparable results, but the CNN model has an advantage in that it can be easily computed in parallel, hence making it faster with recent graphics processing units (GPUs).
 
-For biotopes event extraction, Li et al. employed CNN and distributed representation while Mehryary et al. used long-short term memory (LSTM) networks to extract complicate relations [@doi:10.18653/v1/w16-3012; @doi:10.18653/v1/w16-3009].
-Li et al. applied word embedding to extract complete events from biomedical text and archived the results comparable to the state-of-the-art systems [@doi:10.18653/v1/w15-3814].
-There are also some works that identified event triggers rather than the complete event [@doi:10.1142/S0219720015410012;  @arxiv:1705.09516].
-Taken together, it appears that deep learning models outperform traditional kernel methods or feature-based approaches by 1-5% in f-score.
+For biotopes event extraction, Li et al. employed CNN and distributed representation [@doi:10.18653/v1/w16-3012] while Mehryary et al. used long short-term memory (LSTM) networks to extract complicated relations [@doi:10.18653/v1/w16-3009].
+Li et al. applied word embedding to extract complete events from biomedical text and achieved results comparable to the state-of-the-art systems [@doi:10.18653/v1/w15-3814].
+There are also approaches that identify event triggers rather than the complete event [@doi:10.1142/S0219720015410012; @arxiv:1705.09516].
+Taken together, deep learning models outperform traditional kernel methods or feature-based approaches by 1-5% in f-score.
 Among various deep learning approaches, CNN stands out as the most popular model both in terms of computational complexity and performance, while RNN has achieved continuous progress.
 
 Information retrieval is a task of finding relevant text that satisfies an information need from within a large document collection.
 While deep learning has not yet achieved the same level of success in this area as seen in others, the recent surge of interest and work suggest that this may be quickly changing.
-For example, Mohan et al. described a deep learning approach to modeling the relevance of a document's text to a query, applied to the entire biomedical literature [@doi:10.18653/v1/w17-2328].
+For example, Mohan et al. described a deep learning approach to modeling the relevance of a document's text to a query, which they applied to the entire biomedical literature [@doi:10.18653/v1/w17-2328].
 
-In the clinical domain, Jagannatha and Yu employed a bidirectional LSTM RNN structure to extract adverse drug events from electronic health records [@pmid:27885364].
-Choi et al. developed Doctor AI, a RNN-based model that can learn efficient patient representation from a large amount of longitudinal patient records and predict diagnosis and medication code of EHR [@arxiv:1511.05942].
+In the clinical domain, Jagannatha and Yu employed a bidirectional LSTM structure to extract adverse drug events from electronic health records [@pmid:27885364].
+Choi et al. developed Doctor AI, a RNN-based model that can learn efficient patient representation from a large amount of longitudinal patient records and predict diagnosis and EHR medication codes [@arxiv:1511.05942].
 Minarro-Giménez et al. applied the word2vec [@arxiv:1301.3781] deep learning toolkit to medical corpora and evaluated the efficiency of word2vec in identifying properties of pharmaceuticals based on mid-sized, unstructured medical text corpora without any additional background knowledge [@doi:10.3233/978-1-61499-432-9-584].
 Lin et al. investigated using CNN to extract temporal relations [@doi:10.18653/v1/w17-2341].
-Karimi et al. investigated the applicability of deep learning at autocoding of radiology reports using the International Classification of Diseases [@doi:10.18653/v1/w17-2342; @tag:world2004international].
+Karimi et al. investigated the applicability of deep learning at autocoding radiology reports using ICD [@doi:10.18653/v1/w17-2342; @tag:world2004international].
 
 To summarize, deep learning has shown promising results in many biomedical text mining tasks and applications.
-But to further realize its full potential in this domain, either large size of labeled data and/or technical advancements in current methods coping with limited labeled data are required.
+But to realize its full potential in this domain, either large size of labeled data or technical advancements in current methods coping with limited labeled data are required.
 
 ### Electronic health records
 
@@ -364,8 +358,8 @@ improved by up to 15% when compared to other methods. Choi et
 al. [@arxiv:1511.05942] attempted to model the longitudinal structure of EHRs
 with a RNN to predict future diagnosis and medication prescriptions on a cohort
 of 260,000 patients followed for 8 years (Doctor AI). Pham et al.
-[@arxiv:1602.00357] built upon this concept by utilising a RNN with a long 
-short-term memory (LSTM) architecture enabling explicit modelling of patient
+[@arxiv:1602.00357] built upon this concept by utilising a RNN with a
+LSTM architecture enabling explicit modelling of patient
 trajectories through the use of memory cells. The method, DeepCare, performed
 better than shallow models or plain RNN when tested on two independent cohorts
 for its ability to predict disease progression, intervention recommendation and

--- a/content/06.discussion.md
+++ b/content/06.discussion.md
@@ -415,7 +415,7 @@ Many have sought to curb these costs, with methods ranging from the very applied
 @tag:Sa2015_buckwild; @tag:Hubara2016_qnn]) to the exotic and theoretic (e.g.
 training small networks to mimic large networks and ensembles
 [@tag:Caruana2014_need; @tag:Hinton2015_dark_knowledge]). The largest gains in
-efficiency have come from computation with graphics processing units (GPUs)
+efficiency have come from computation with GPUs
 [@tag:Raina2009_gpu; @tag:Vanhoucke2011_cpu; @tag:Seide2014_parallel;
 @tag:Hadjas2015_cc; @tag:Edwards2015_growing_pains;
 @tag:Schmidhuber2014_dnn_overview], which excel at the matrix and vector


### PR DESCRIPTION
Following up on #567, I tried to condense some of the NLP section in categorize without losing any of the main points.  There were also several inconsistent acronyms.  @luzh2 can you please review to make sure the edited version is still correct?

After we merge this, we need to fix the clinical EHR sections.  We now have an EHR paragraph in the text mining sub-section and a text mining paragraph in the following EHR sub-section.  They mention some of the same papers.  This should be collapsed, and we need a better transition from the text mining to EHR sub-sections.