### PR TITLE
New author template

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -135,7 +135,7 @@ author_info:
     orcid: 0000-0001-9309-8331
     email: yifan.peng@nih.gov
     affiliations: National Center for Biotechnology Information and National Library of Medicine, National Institutes of Health, Bethesda, MD
-    funders: OTHER National Institutes of Health Intramural Research Program and National Library of Medicine
+    funders: National Institutes of Health Intramural Research Program and National Library of Medicine
   - github: laurakwiley
     name: Laura K. Wiley
     orcid: 0000-0001-6681-9754

--- a/content/new-author-metadata.yaml
+++ b/content/new-author-metadata.yaml
@@ -1,0 +1,15 @@
+---
+author_info:
+  - github: johndoe
+    name: John Doe
+    initials: JD
+    orcid: XXXX-XXXX-XXXX-XXXX
+    email: john.doe@something.com
+    affiliations: Department of Something, University of Whatever
+    funders: Grant XXXXXXXX
+  - github: janeroe
+    name: Jane R. Roe
+    initials: JRR
+    orcid: XXXX-XXXX-XXXX-XXXX
+    email: jane.roe@whatever.edu
+    affiliations: Department of Whatever, University of Something


### PR DESCRIPTION
I'm adding a temporary authors template.  The new authors in #561 can add their information here. 
 Then I'll randomly insert them into the order and `metadata.yaml` using the previous [algorithm](https://github.com/greenelab/deep-review/blob/master/authors/author-order.ipynb).  I dropped the `twitter` key-value pair because we aren't using that in this manuscript and left two example authors from manubot-rootstock.

Also fixing a funding error from our previous author table.