### PR TITLE
Update published arXiv papers per manubot warnings

### DIFF
--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -192,14 +192,14 @@ This demonstrates how deep learning methods can repurpose features across tasks,
 The Discussion further reviews this type of transfer learning.
 
 Several authors have created reusable feature sets for medical terminologies using natural language processing and neural embedding models, as popularized by word2vec [@arxiv:1301.3781].
-Minarro-Giménez et al. [@doi:10.3233/978-1-61499-432-9-584] applied the word2vec deep learning toolkit to medical corpora and evaluated the efficiency of word2vec in identifying properties of pharmaceuticals based on mid-sized, unstructured medical text corpora without any additional background knowledge. 
+Minarro-Giménez et al. [@doi:10.3233/978-1-61499-432-9-584] applied the word2vec deep learning toolkit to medical corpora and evaluated the efficiency of word2vec in identifying properties of pharmaceuticals based on mid-sized, unstructured medical text corpora without any additional background knowledge.
 A goal of learning terminologies for different entities in the same vector space is to find relationships between different domains (e.g. drugs and the diseases they treat).
 It is difficult for us to provide a strong statement on the broad utility of these methods.
 Manuscripts in this area tend to compare algorithms applied to the same data but lack a comparison against overall best-practices for one or more tasks addressed by these methods.
 Techniques have been developed for free text medical notes [@doi:10.1145/2661829.2661974], ICD and National Drug Codes [@doi:10.18653/v1/w17-2342; @tag:world2004international], and claims data [@doi:10.1145/2939672.2939823].
-Methods for neural embeddings learned from electronic health records have at least some ability to predict disease-disease associations and implicate genes with a statistical association with a disease [@doi:10.1038/srep32404], but the evaluations performed did not differentiate between simple predictions (i.e. the same disease in different sites of the body) and non-intuitive ones. 
+Methods for neural embeddings learned from electronic health records have at least some ability to predict disease-disease associations and implicate genes with a statistical association with a disease [@doi:10.1038/srep32404], but the evaluations performed did not differentiate between simple predictions (i.e. the same disease in different sites of the body) and non-intuitive ones.
 Jagannatha and Yu  [@pmid:27885364] further employed a bidirectional LSTM structure to extract adverse drug events from electronic health records, and Lin et al. [@doi:10.18653/v1/w17-2341] investigated using CNN to extract temporal relations.
-While promising, a lack of rigorous evaluations of the real-world utility of these kinds of features makes current contributions in this area difficult to evaluate. 
+While promising, a lack of rigorous evaluations of the real-world utility of these kinds of features makes current contributions in this area difficult to evaluate.
 Comparisons need to be performed to examine the true utility against leading approaches (i.e. algorithms and data) as opposed to simply evaluating multiple algorithms on the same potentially limited dataset.
 
 Identifying consistent subgroups of individuals and individual health trajectories from clinical tests is also an active area of research.
@@ -330,7 +330,7 @@ Even without sharing data, algorithms trained on confidential patient data may p
 Tramer et al. [@arxiv:1609.02943] showed the ability to steal trained models via public application programming interfaces (APIs).
 Dwork and Roth [@doi:10.1561/0400000042] demonstrate the ability to expose individual level information from accurate answers in a machine learning model.
 Attackers can use similar attacks to find out if a particular data instance was present in the original training set for the machine learning model [@arxiv:1610.05820], in this case, whether a person's record was present.
-To protect against these attacks, Simmons et al. [@doi:10.1016/j.cels.2016.04.013] developed the ability to perform genome-wide association studies (GWASs) in a differentially private manner, and Abadi et al. [@arxiv:1607.00133] show the ability to train deep learning classifiers under the differential privacy framework.
+To protect against these attacks, Simmons et al. [@doi:10.1016/j.cels.2016.04.013] developed the ability to perform genome-wide association studies (GWASs) in a differentially private manner, and Abadi et al. [@doi:10.1145/2976749.2978318] show the ability to train deep learning classifiers under the differential privacy framework.
 
 These attacks also present a potential hazard for approaches that aim to generate data.
 Choi et al. propose generative adversarial neural networks (GANs) as a tool to make sharable EHR data [@arxiv:1703.06490v1], and Esteban et al. [@arxiv:1706.02633v1] showed that recurrent GANs could be used for time series data.

--- a/content/06.discussion.md
+++ b/content/06.discussion.md
@@ -301,7 +301,7 @@ A pre-trained neural network can be quickly fine-tuned on new data and used in t
 Taking this idea to the extreme, genomic data has been artificially encoded as images in order to benefit from pre-trained image classifiers [@tag:Poplin2016_deepvariant].
 "Model zoos" -- collections of pre-trained models -- are not yet common in biomedical domains but have started to appear in genomics applications [@tag:Angermueller2016_single_methyl; @tag:Dragonn].
 However, it is important to note that sharing models trained on individual data requires great care because deep learning models can be attacked to identify examples used in training.
-One possible solution to protect individual samples includes training models under differential privacy [@arxiv:1607.00133], which has been used in the biomedical domain [@doi:10.1101/159756].
+One possible solution to protect individual samples includes training models under differential privacy [@doi:10.1145/2976749.2978318], which has been used in the biomedical domain [@doi:10.1101/159756].
 We discussed this issue as well as recent techniques to mitigate these concerns in the patient categorization section.
 
 DeepChem [@tag:AltaeTran2016_one_shot; @tag:DeepChem; @tag:Wu2017_molecule_net] and DragoNN [@tag:Dragonn] exemplify the benefits of sharing pre-trained models and code under an open source license.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -23,7 +23,7 @@ Berezikov2011_mirna	doi:10.1038/nrg3079
 Bergstra2011_hyper	url:https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf
 Bergstra2012_random	url:http://www.jmlr.org/papers/v13/bergstra12a.html
 Bracken2016_mirna	doi:10.1038/nrg.2016.134
-Boza	arxiv:1603.09195
+Boza	doi:10.1371/journal.pone.0178751
 Buggenthin2017_imaged_lineage	doi:10.1038/nmeth.4182
 Burlina2016_amd	doi:10.1109/ISBI.2016.7493240
 Caruana2014_need	arxiv:1312.6184
@@ -99,7 +99,7 @@ Hubara2016_qnn	arxiv:1609.07061
 Huddar2016_predicting	doi:10.1109/ACCESS.2016.2618775
 Hughes2016_macromol_react	doi:10.1021/acscentsci.6b00162
 Ithapu2015_efficient	doi:10.1016/j.jalz.2015.01.010
-Jafari2016_skin_lesions	arxiv:1609.02374
+Jafari2016_skin_lesions	doi:10.1007/s11548-017-1567-8
 Jha2017_integrative_models	doi:10.1101/104869
 Johnson2017_integ_cell	arxiv:1705.00092
 JuanMateu2016_t1d	doi:10.1530/EJE-15-0916
@@ -135,7 +135,7 @@ Lin2017_why_dl_works	arxiv:1608.08225v3
 Lipton2016_missing	arxiv:1606.04130
 Lipton2015_lstm	arxiv:1510.07641
 Litjens2016_histopath_survey	doi:10.1038/srep26286
-Litjens2017_medimage_survey	arxiv:1702.05747
+Litjens2017_medimage_survey	doi:10.1016/j.media.2017.07.005
 Lisboa2006_review	doi:10.1016/j.neunet.2005.10.007
 Liu	doi:10.1371/journal.pone.0097958
 Liu2016_towards	arxiv:1604.07043
@@ -208,7 +208,7 @@ Seide2014_parallel	doi:10.1109/ICASSP.2014.6853593
 Setty2015_seqgl	doi:10.1371/journal.pcbi.1004271
 Selvaraju2016_grad	arxiv:1610.02391
 Serden	doi:10.1016/S0168-8510(02)00208-7
-Shaham2016_batch_effects	arxiv:1610.04181
+Shaham2016_batch_effects	doi:10.1093/bioinformatics/btx196
 Shapely	doi:10.1515/9781400881970-018
 Shen2017_medimg_review	doi:10.1146/annurev-bioeng-071516-044442
 Shin2016_cad_tl	doi:10.1109/TMI.2016.2528162
@@ -218,7 +218,7 @@ Simonyan2013_deep	arxiv:1312.6034
 Singh2017_attentivechrome	arxiv:1708.00339
 Singh2016_deepchrome	arxiv:1607.02078
 Silver2016_alphago	doi:10.1038/nature16961
-Sonderby	arxiv:1503.01919
+Sonderby	doi:10.1007/978-3-319-21233-3_6
 Soueidan	doi:10.1515/metgen-2016-0001
 Spark	doi:10.1145/2934664
 Speech_recognition	url:http://www.businessinsider.com/ibm-edges-closer-to-human-speech-recognition-2017-3


### PR DESCRIPTION
I updated all of the arXiv references that have now been published per the warnings in [this build](https://travis-ci.org/greenelab/deep-review/builds/326798639#L1427).  I verified that the authors were the same in the arXiv and published versions.  In some cases the titles or abstracts changed.

Do we want to scrutinize the arXiv and published versions more before making these updates?  I assume that we prefer the final versions in general.

Partially addresses #699.