### PR TITLE
Update Categorize section lede, remove LADA

### DIFF
--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -7,6 +7,7 @@ While these rules are refined over time, the process is evolutionary and ad hoc,
 Deep learning methods coupled with a large corpus of patient phenotypes may provide a more data-driven approach to patient categorization.
 A meaningful contribution to patient categorization would be to identify new shared mechanisms that would otherwise be obscured due to ad hoc historical definitions of disease.
 Perhaps deep neural networks, by reevaluating data without the context of our assumptions, can reveal novel classes of treatable conditions.
+
 In spite of such optimism, the ability of deep learning models to indiscriminately extract predictive signals must also be assessed and operationalized with care.
 Imagine a deep neural network is provided with clinical test results gleaned from electronic health records.
 Because physicians may order certain tests based on their suspected diagnosis, a deep neural network may learn to "diagnose" patients simply based on the tests that are ordered.

--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -4,8 +4,8 @@ In healthcare, individuals are diagnosed with a disease or condition based on sy
 Once diagnosed with a disease, an individual might be assigned a stage based on another set of human-defined rules.
 While these rules are refined over time, the process is evolutionary and ad hoc, potentially impeding the identification of underlying biological mechanisms and their corresponding treatment interventions.
 
-Deep learning methods coupled with a large corpus of patient phenotypes may provide a more data-driven approach to patient categorization.
-A meaningful contribution to patient categorization would be to identify new shared mechanisms that would otherwise be obscured due to ad hoc historical definitions of disease.
+Deep learning methods applied to a large corpus of patient phenotypes may provide a meaningful and more data-driven approach to patient categorization.
+For example, they may identify new shared mechanisms that would otherwise be obscured due to ad hoc historical definitions of disease.
 Perhaps deep neural networks, by reevaluating data without the context of our assumptions, can reveal novel classes of treatable conditions.
 
 In spite of such optimism, the ability of deep learning models to indiscriminately extract predictive signals must also be assessed and operationalized with care.

--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -5,18 +5,8 @@ Once diagnosed with a disease, an individual might be assigned a stage based on 
 While these rules are refined over time, the process is evolutionary and ad hoc, potentially impeding the identification of underlying biological mechanisms and their corresponding treatment interventions.
 
 Deep learning methods coupled with a large corpus of patient phenotypes may provide a more data-driven approach to patient categorization.
-A deep neural network has the potential to identify entirely new categories of health or disease that are only present when data from multiple lab tests are integrated.
-
-As an example, consider the condition Latent Autoimmune Diabetes in Adults
-(LADA; reviewed in [@doi:10.2337/diabetes.54.suppl_2.S68]).
-In the absence of a pre-specified disease definition, a deep neural network might have identified a subgroup of individuals with blood glucose levels that indicated diabetes as well as auto-antibodies, even though the individuals had never been diagnosed with type 1 diabetes -- the autoimmune form of the disease that arises in young people.
-Such a neural network would be identifying patients with LADA.
-As no such computational approach existed, LADA was actually identified by Groop et al. [@doi:10.2337/diab.35.2.237].
-
-One should not regard recapitulation of existing disease categories as a gold-standard for deep learning results.
-Instead, a meaningful contribution to patient categorization would be to identify new shared mechanisms that would otherwise be obscured due to ad hoc historical definitions of disease.
+A meaningful contribution to patient categorization would be to identify new shared mechanisms that would otherwise be obscured due to ad hoc historical definitions of disease.
 Perhaps deep neural networks, by reevaluating data without the context of our assumptions, can reveal novel classes of treatable conditions.
-
 In spite of such optimism, the ability of deep learning models to indiscriminately extract predictive signals must also be assessed and operationalized with care.
 Imagine a deep neural network is provided with clinical test results gleaned from electronic health records.
 Because physicians may order certain tests based on their suspected diagnosis, a deep neural network may learn to "diagnose" patients simply based on the tests that are ordered.
@@ -108,16 +98,16 @@ In other domains, this has resulted in a minimal change in the estimated accurac
 
 Rich clinical information is stored in EHRs.
 However, manually annotating a large set requires experts and is time consuming.
-For chest X-ray studies, a radiologist usually spends a few minutes per example. 
+For chest X-ray studies, a radiologist usually spends a few minutes per example.
 Generating the number of examples needed for deep learning is infeasibly expensive.
 Instead, researchers may benefit from using text mining to generate annotations [@doi:10.3115/1572392.1572411], even if those annotations are of modest accuracy.
 Wang et al. [@arxiv:1705.02315] proposed to build predictive DL models through the use of images with *weak labels*.
 Such labels are automatically generated and not verified by humans, so they may be noisy or incomplete.
-In this case, they applied a series of natural language processing (NLP) techniques to the associated chest X-ray radiological reports. 
-They first extracted all diseases mentioned in the reports using a state-of-the-art NLP tool, then applied a newly-developed negation and uncertainty detection tool (NegBio [@arxiv:1712.05898]) to filter negative and equivocal findings in the reports. 
+In this case, they applied a series of natural language processing (NLP) techniques to the associated chest X-ray radiological reports.
+They first extracted all diseases mentioned in the reports using a state-of-the-art NLP tool, then applied a newly-developed negation and uncertainty detection tool (NegBio [@arxiv:1712.05898]) to filter negative and equivocal findings in the reports.
 Evaluation on four independent datasets demonstrated that NegBio is highly accurate for detecting negative and equivocal findings (~90% in F-measure, which balances precision and recall [@doi:10.1038/nmeth.3945]).
 The resulting dataset [@url:https://nihcc.app.box.com/v/ChestXray-NIHCC] consisted of 112,120 frontal-view chest X-ray images from 30,805 patients, and each image was associated with one or more *text-mined* (weakly-labeled) pathology categories (e.g. pneumonia and cardiomegaly) or "no finding" otherwise.
-Further, Wang et al. [@arxiv:1705.02315] used this dataset with a unified weakly-supervised multi-label image classification framework, to detect common thoracic diseases. 
+Further, Wang et al. [@arxiv:1705.02315] used this dataset with a unified weakly-supervised multi-label image classification framework, to detect common thoracic diseases.
 It showed superior performance over a benchmark using fully-labeled data.
 
 With the exception of natural image-like problems (e.g. melanoma detection), biomedical imaging poses a number of challenges for deep learning.


### PR DESCRIPTION
A reviewer criticized the LADA example in #685. From a read through, I think the reviewer is right. This is out of sync with the tone of the rest of the paper. This PR removes the LADA mention and collapses the lede to the intro to the categorize section. It also cleans up a little bit of trailing whitespace later in the section.