### PR TITLE
Frontmatter: use numbered affiliations

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -18,6 +18,9 @@ on {{date}}.
 ## Authors
 
 {% for author in authors %}
+{% if author.orcid is defined -%}
+[![ORCID icon](images/orcid.svg){height="11px" width="11px"}](https://orcid.org/{{author.orcid}})
+{%- endif %}
 {{author.name}}<sup>{{author.affiliation_numbers | join(',')}}</sup>
 {%- if not loop.last -%}, {%- endif -%}
 {% endfor %}

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -21,9 +21,12 @@ on {{date}}.
 {% if author.orcid is defined -%}
 [![ORCID icon](images/orcid.svg){height="11px" width="11px"}](https://orcid.org/{{author.orcid}})
 {%- endif %}
-{{author.name}}<sup>{{author.affiliation_numbers | join(',')}}</sup>
+{{author.name}}<sup>{{author.affiliation_numbers | join(',')}}{%- if author.symbol_str is defined -%},{{author.symbols | join(',')}}{%- endif -%}</sup>
 {%- if not loop.last -%}, {%- endif -%}
 {% endfor %}
+
+<sup>☯</sup> --- Author order was determined with a randomized algorithm<br>
+<sup>†</sup> --- To whom correspondence should be addressed: `gitter` at `biostat.wisc.edu` (AG) and `csgreene` at `upenn.edu` (CSG)
 <small>
 
 {% for affiliation in affiliations %}

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -17,27 +17,14 @@ on {{date}}.
 
 ## Authors
 
-{## Template for listing authors ##}
 {% for author in authors %}
-+ **{{author.name}}**<br>
-  {%- if author.orcid is defined %}
-    ![ORCID icon](images/orcid.svg){height="13px" width="13px"}
-    [{{author.orcid}}](https://orcid.org/{{author.orcid}})
-  {%- endif %}
-  {%- if author.github is defined %}
-    · ![GitHub icon](images/github.svg){height="13px" width="13px"}
-    [{{author.github}}](https://github.com/{{author.github}})
-  {%- endif %}
-  {%- if author.twitter is defined %}
-    · ![Twitter icon](images/twitter.svg){height="13px" width="13px"}
-    [{{author.twitter}}](https://twitter.com/{{author.twitter}})
-  {%- endif %}<br>
-  <small>
-  {%- if author.affiliations is defined %}
-     {{author.affiliations | join('; ')}}
-  {%- endif %}
-  {%- if author.funders is defined %}
-     · Funded by {{author.funders}}
-  {%- endif %}
-  </small>
+{{author.name}}<sup>{{author.affiliation_numbers | join(',')}}</sup>
+{%- if not loop.last -%}, {%- endif -%}
 {% endfor %}
+<small>
+
+{% for affiliation in affiliations %}
+{{affiliation.affiliation_number}}. {{affiliation.affiliation}}
+{%- endfor %}
+
+</small>

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -17,6 +17,7 @@ author_info:
     email: traversc@gmail.com
     affiliations:
       - Molecular Biosciences and Bioengineering Graduate Program, University of Hawaii at Manoa, Honolulu, HI
+    symbol_str: "☯"
   - github: dhimmel
     name: Daniel S. Himmelstein
     orcid: 0000-0002-3012-7446
@@ -179,6 +180,7 @@ author_info:
       - Department of Biostatistics and Medical Informatics, University of Wisconsin-Madison
       - Morgridge Institute for Research, Madison, WI
     funders: NIH U54AI117924
+    symbol_str: "†"
   - github: cgreene
     name: Casey S. Greene
     orcid: 0000-0001-8713-9213
@@ -186,3 +188,4 @@ author_info:
     affiliations:
       - Department of Systems Pharmacology and Translational Therapeutics, Perelman School of Medicine, University of Pennsylvania, Philadelphia, PA
     funders: GBMF GBMF4552
+    symbol_str: "†"


### PR DESCRIPTION
Switch frontmatter to condensed format which uses numbered affiliations.

Refs https://github.com/greenelab/deep-review/issues/700