### PR TITLE
Fix missing symbols after author names

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -21,7 +21,7 @@ on {{date}}.
 {% if author.orcid is defined -%}
 [![ORCID icon](images/orcid.svg){height="11px" width="11px"}](https://orcid.org/{{author.orcid}})
 {%- endif %}
-{{author.name}}<sup>{{author.affiliation_numbers | join(',')}}{%- if author.symbol_str is defined -%},{{author.symbols | join(',')}}{%- endif -%}</sup>
+{{author.name}}<sup>{{author.affiliation_numbers | join(',')}}{%- if author.symbol_str is defined -%},{{author.symbol_str}}{%- endif -%}</sup>
 {%- if not loop.last -%}, {%- endif -%}
 {% endfor %}
 


### PR DESCRIPTION
Error from https://github.com/greenelab/deep-review/pull/769