### PR TITLE
Split affiliations and correct typo

### DIFF
--- a/content/04.study.md
+++ b/content/04.study.md
@@ -287,7 +287,7 @@ DeepPPI [@doi:10.1021/acs.jcim.7b00028] made PPI predictions from a set of seque
 Sun et al. [@doi:10.1186/s12859-017-1700-2] applied autocovariances, a coding scheme that returns uniform-size vectors describing the covariance between physicochemical properties of the protein sequence at various positions.
 Wang et al. [@doi:10.1039/C7MB00188F] used deep learning as an intermediate step in PPI prediction.
 They examined 70 amino acid protein sequences from each of which they extracted 1260 features.
-A stacked sparse autoencoder with two hidden layers was then used to reduce feature dimensions and noisiness before a novel type of classification vector machine made PPI predictions. 
+A stacked sparse autoencoder with two hidden layers was then used to reduce feature dimensions and noisiness before a novel type of classification vector machine made PPI predictions.
 
 Beyond predicting whether or not two proteins interact, Du et al. [@doi:10.1016/j.ymeth.2016.06.001] employed a deep learning approach to predict the residue contacts between two interacting proteins.
 Using features that describe how similar a protein's residue is relative to similar proteins at the same position, the authors extracted uniform-length features for each residue in the protein sequence.
@@ -312,7 +312,7 @@ MHCflurry adds placeholder amino acids to transform variable-length peptides to 
 In training the MHCflurry feed-forward neural network [@doi:10.1101/054775], the authors imputed missing MHC-peptide binding affinities using a Gibbs sampling method, showing that imputation improves performance for data-sets with roughly 100 or fewer training examples.
 MHCflurry's imputation method increases its performance on poorly characterized alleles, making it competitive with NetMHCpan for this task.
 Kuksa et al. [@doi:10.1093/bioinformatics/btv371] developed a shallow, higher-order neural network (HONN) comprised of both mean and covariance hidden units to capture some of the higher-order dependencies between amino acid locations.
-Pretraining this HONN with a semi-restricted Boltzmann machine, the authors found that the performance of the HONN exceeded that of a simple DNN, as well as that of NetMHC.
+Pretraining this HONN with a semi-restricted Boltzmann machine, the authors found that the performance of the HONN exceeded that of a simple deep neural network, as well as that of NetMHC.
 
 Deep learning's unique flexibility was recently leveraged by Bhattacharya et al. [@doi:10.1101/154757], who used a gated RNN method called MHCnuggets to overcome the difficulty of multiple length peptides.
 Under this framework, they used smoothed sparse encoding to represent amino acids individually.

--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -151,7 +151,8 @@ author_info:
     orcid: 0000-0003-3084-2287
     email: akundaje@stanford.edu
     affiliations:
-      - Department of Genetics and Department of Computer Science, Stanford University, Stanford, CA
+      - Department of Genetics, Stanford University, Stanford, CA
+      - Department of Computer Science, Stanford University, Stanford, CA
     funders: NIH DP2GM123485
   - github: yfpeng
     name: Yifan Peng


### PR DESCRIPTION
Now that we have better support for multiple affiliations, I'm splitting @akundaje's.

This will avoid having `Department of Computer Science, Stanford University, Stanford, CA` and `Department of Genetics and Department of Computer Science, Stanford University, Stanford, CA` as separate affiliations.