### PR TITLE
Cite ImageNet and CIFAR datasets

### DIFF
--- a/content/06.discussion.md
+++ b/content/06.discussion.md
@@ -234,7 +234,7 @@ A linear model trained on heavily engineered features might be difficult to inte
 Similarly, a decision tree with many nodes and branches may also be difficult for a human to make sense of.
 
 There are several directions that might benefit the development of interpretability techniques.
-The first is the introduction of gold standard benchmarks that different interpretability approaches could be compared against, similar in spirit to how datasets like ImageNet and CIFAR spurred the development of deep learning for computer vision.
+The first is the introduction of gold standard benchmarks that different interpretability approaches could be compared against, similar in spirit to how the ImageNet [@doi:10.1007/s11263-015-0816-y] and CIFAR [@url:https://www.cs.toronto.edu/~kriz/learning-features-2009-TR.pdf] datasets spurred the development of deep learning for computer vision.
 It would also be helpful if the community placed more emphasis on domains outside of computer vision.
 Computer vision is often used as the example application of interpretability methods, but it is not the domain with the most pressing need.
 Finally, closer integration of interpretability approaches with popular deep learning frameworks would make it easier for practitioners to apply and experiment with different approaches to understanding their deep learning models.


### PR DESCRIPTION
Also change CIFAR into a modifier of "dataset" instead of a noun on its own.

addresses greenelab/deep-review#615