### PR TITLE
add GATK citation `@doi:10.1038/ng.806`.

### DIFF
--- a/content/04.study.md
+++ b/content/04.study.md
@@ -456,7 +456,7 @@ One of these models, DeepVariant, leverages Inception, a neural network trained 
 The top 5 rows represent the reference, and the bottom 95 rows represent randomly sampled reads that overlap the candidate variant.
 Each RGBA (red/green/blue/alpha) image pixel encodes the base (A, C, G, T) as a different red value, quality score as a green value, strand as a blue value, and variation from the reference as the alpha value.
 The neural network outputs genotype probabilities for each candidate variant.
-They were able to achieve better performance than GATK, a leading genotype caller, even when GATK was given information about population variation for each candidate variant.
+They were able to achieve better performance than GATK [@doi:10.1038/ng.806], a leading genotype caller, even when GATK was given information about population variation for each candidate variant.
 Another method, still in its infancy, hand-developed 62 features for each candidate variant and fed these vectors into a fully connected deep neural network [@tag:Torracinta2016_deep_snp].
 Unfortunately, this feature set required at least 15 iterations of software development to fine-tune, which suggests that these models may not generalize.
 


### PR DESCRIPTION
This is the same citation used by `@tag:Poplin2016_deepvariant` in their paper.

Addresses greenelab/deep-review#611.