### PR TITLE
`serum urine acid` -> `serum uric acid`

### DIFF
--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -391,7 +391,7 @@ In large patient populations, longitudinal analyses such as the Framingham Heart
 Yet, a common practice in EHR-based research is to take a snapshot at a point in time and convert patient data to a traditional vector for machine learning and statistical analysis.
 This results in loss of information as timing and order of events can provide insight into a patient's disease and treatment [@doi:10.2307/2281868].
 Efforts to model sequences of events have shown promise [@doi:10.1038/ncomms5022] but require exceedingly large patient sizes due to discrete combinatorial bucketing.
-Lasko et al. [@doi:10.1371/journal.pone.0066341] used autoencoders on longitudinal sequences of serum urine acid measurements to identify population subtypes.
+Lasko et al. [@doi:10.1371/journal.pone.0066341] used autoencoders on longitudinal sequences of serum uric acid measurements to identify population subtypes.
 More recently, deep learning has shown promise working with both sequences (CNNs)
 [@arxiv:1607.07519] and the incorporation of past and current state (RNNs, LSTMs) [@arxiv:1602.00357].
 This may be a particular area of opportunity for deep neural networks.


### PR DESCRIPTION
Addresses greenelab/deep-review#607.