### PR TITLE
remove `negation and uncertainty detection tool`

### DIFF
--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -106,7 +106,7 @@ Instead, researchers may benefit from using text mining to generate annotations 
 Wang et al. [@arxiv:1705.02315] proposed to build predictive DL models through the use of images with *weak labels*.
 Such labels are automatically generated and not verified by humans, so they may be noisy or incomplete.
 In this case, they applied a series of natural language processing (NLP) techniques to the associated chest X-ray radiological reports.
-They first extracted all diseases mentioned in the reports using a state-of-the-art NLP tool, then applied a newly-developed negation and uncertainty detection tool (NegBio [@arxiv:1712.05898]) to filter negative and equivocal findings in the reports.
+They first extracted all diseases mentioned in the reports using a state-of-the-art NLP tool, then applied a new method, NegBio [@arxiv:1712.05898], to filter negative and equivocal findings in the reports.
 Evaluation on four independent datasets demonstrated that NegBio is highly accurate for detecting negative and equivocal findings (~90% in F-measure, which balances precision and recall [@doi:10.1038/nmeth.3945]).
 The resulting dataset [@url:https://nihcc.app.box.com/v/ChestXray-NIHCC] consisted of 112,120 frontal-view chest X-ray images from 30,805 patients, and each image was associated with one or more *text-mined* (weakly-labeled) pathology categories (e.g. pneumonia and cardiomegaly) or "no finding" otherwise.
 Further, Wang et al. [@arxiv:1705.02315] used this dataset with a unified weakly-supervised multi-label image classification framework, to detect common thoracic diseases.


### PR DESCRIPTION
It is unnecessary to explain NegBio.

Addresses greenelab/deep-review#601.