### PR TITLE
Updated affiliation for evancofer in content/metadata.yaml

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -145,6 +145,7 @@ author_info:
     email: ecofer@princeton.edu
     affiliations:
       - Department of Computer Science, Trinity University, San Antonio, TX
+      - Lewis-Sigler Institute for Integrative Genomics, Princeton University, Princeton, NJ
     funders: NSF 1531594
   - github: lavenderca
     name: Christopher A. Lavender


### PR DESCRIPTION
As the title says, I have updated my institutional affiliations in the metadata. I contributed writing and work while at both Trinity and Princeton.