### PR TITLE
Add URL to manual reference

### DIFF
--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -1186,7 +1186,8 @@
          "2009"
        ]
      ]
-   }
+   },
+   "URL": "https://www.cs.toronto.edu/~kriz/learning-features-2009-TR.pdf"
  },
  {
    "indexed": {


### PR DESCRIPTION
Missed URL in #796.  I'm going to merge myself if it builds.