### PR TITLE
Fix broken Gal reference

### DIFF
--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -294,4 +294,4 @@ bayesian_hypernets	arxiv:1710.04759
 mcclure_bayesian	arxiv:1611.01639
 uncertainty_ensembles	arxiv:1612.01474
 domain_adapt_uncertainty	arxiv:1505.07818
-gal_thesis	url:http://www.cs.ox.ac.uk/people/yarin.gal/website/publications.html#Gal2015Thesis
+gal_thesis	url:http://www.cs.ox.ac.uk/people/yarin.gal/website/thesis/thesis.pdf

--- a/content/manual-references.json
+++ b/content/manual-references.json
@@ -1308,5 +1308,26 @@
    "container-title-short": "IEEE J. Biomed. Health Inform.",
    "short_url": "https://doi.org/gcgnxx",
    "standard_citation": "doi:10.1109/jbhi.2016.2633963"
+ },
+ {
+   "standard_citation": "url:http://www.cs.ox.ac.uk/people/yarin.gal/website/thesis/thesis.pdf",
+   "type": "thesis",
+   "title": "Uncertainty in deep learning",
+   "publisher": "PhD thesis, University of Cambridge",
+   "genre": "PhD thesis",
+   "URL": "http://www.cs.ox.ac.uk/people/yarin.gal/website/thesis/thesis.pdf",
+   "author": [
+     {
+       "family": "Gal",
+       "given": "Yarin"
+     }
+   ],
+   "issued": {
+     "date-parts": [
+       [
+         "2016"
+       ]
+     ]
+   }
  }
 ]


### PR DESCRIPTION
Showed up as
`432. Yarin Gal - Publications | Oxford Machine Learning http://www.cs.ox.ac.uk/people/yarin.gal/website/publications.html`

This may require a manual override, but I'm trying this first.