### PR TITLE
2 examples of small data training in medical imaging

### DIFF
--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -80,7 +80,7 @@ In more recent work, Wang et al. [@tag:Wang2016_breast_cancer] analyzed stained 
 On this task a pathologist has about a 3% error rate.
 The pathologist did not produce any false positives, but did have a number of false negatives.
 The algorithm had about twice the error rate of a pathologist, but the errors were not strongly correlated.
-Combining pre-trained deep network architectures with multiple augmentation techniques, including different rotations, image scales, crop sizes, and image normalization methods enables accurate detection of breast cancer from a very small set of histology images with less than a 100 images per class [@tag:Rakhlin2018_histology].
+Combining pre-trained deep network architectures with multiple augmentation techniques enabled accurate detection of breast cancer from a very small set of histology images with less than 100 images per class [@tag:Rakhlin2018_histology].
 In this area, these algorithms may be ready to be incorporated into existing tools to aid pathologists and reduce the false negative rate.
 Ensembles of deep learning and human experts may help overcome some of the challenges presented by data limitations.
 
@@ -107,8 +107,8 @@ It showed superior performance over a benchmark using fully-labeled data.
 
 Another example of semi-automated label generation for hand radiograph segmentation employed positive mining, an iterative procedure that combines manual labeling with automatic processing [@tag:Iglovikov2017_baa].
 First, the initial training set was created by manually labeling 100 of 12,600 unlabeled radiographs that were used to train a model and predict labels for the rest of the dataset.
-Then, through manual inspection, poor quality predictions were discarded, while the initial training set was expanded with the acceptable segmentations, and the process was repeated.
-This procedure had to be repeated 6 times to obtain good quality segmentation labeling for all radiographs, except for a last 100 corner cases that still required manual annotation.
+Then, poor quality predictions were discarded through manual inspection, the initial training set was expanded with the acceptable segmentations, and the process was repeated.
+This procedure had to be repeated six times to obtain good quality segmentation labeling for all radiographs, except for 100 corner cases that still required manual annotation.
 These annotations allowed accurate segmentation of all hand images in the test set and boosted the final performance in radiograph classification [@tag:Iglovikov2017_baa].
 
 With the exception of natural image-like problems (e.g. melanoma detection), biomedical imaging poses a number of challenges for deep learning.

--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -80,6 +80,7 @@ In more recent work, Wang et al. [@tag:Wang2016_breast_cancer] analyzed stained 
 On this task a pathologist has about a 3% error rate.
 The pathologist did not produce any false positives, but did have a number of false negatives.
 The algorithm had about twice the error rate of a pathologist, but the errors were not strongly correlated.
+Combining pre-trained deep network architectures with multiple augmentation techniques, including different rotations, image scales, crop sizes, and image normalization methods enables accurate detection of breast cancer from a very small set of histology images with less than a 100 images per class [@tag:Rakhlin2018_histology].
 In this area, these algorithms may be ready to be incorporated into existing tools to aid pathologists and reduce the false negative rate.
 Ensembles of deep learning and human experts may help overcome some of the challenges presented by data limitations.
 
@@ -103,6 +104,12 @@ Evaluation on four independent datasets demonstrated that NegBio is highly accur
 The resulting dataset [@url:https://nihcc.app.box.com/v/ChestXray-NIHCC] consisted of 112,120 frontal-view chest X-ray images from 30,805 patients, and each image was associated with one or more *text-mined* (weakly-labeled) pathology categories (e.g. pneumonia and cardiomegaly) or "no finding" otherwise.
 Further, Wang et al. [@arxiv:1705.02315] used this dataset with a unified weakly-supervised multi-label image classification framework, to detect common thoracic diseases.
 It showed superior performance over a benchmark using fully-labeled data.
+
+Another example of semi-automated label generation for hand radiograph segmentation employed positive mining, an iterative procedure that combines manual labeling with automatic processing [@tag:Iglovikov2017_baa].
+First, the initial training set was created by manually labeling 100 of 12,600 unlabeled radiographs that were used to train a model and predict labels for the rest of the dataset.
+Then, through manual inspection, poor quality predictions were discarded, while the initial training set was expanded with the acceptable segmentations, and the process was repeated.
+This procedure had to be repeated 6 times to obtain good quality segmentation labeling for all radiographs, except for a last 100 corner cases that still required manual annotation.
+These annotations allowed accurate segmentation of all hand images in the test set and boosted the final performance in radiograph classification [@tag:Iglovikov2017_baa].
 
 With the exception of natural image-like problems (e.g. melanoma detection), biomedical imaging poses a number of challenges for deep learning.
 Datasets are typically small, annotations can be sparse, and images are often high-dimensional, multimodal, and multi-channel.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -100,6 +100,7 @@ Horton1992_assessment	doi:10.1093/nar/20.16.4331
 Hubara2016_qnn	arxiv:1609.07061
 Huddar2016_predicting	doi:10.1109/ACCESS.2016.2618775
 Hughes2016_macromol_react	doi:10.1021/acscentsci.6b00162
+Iglovikov2017_baa	doi:10.1101/234120
 Ithapu2015_efficient	doi:10.1016/j.jalz.2015.01.010
 Jafari2016_skin_lesions	doi:10.1007/s11548-017-1567-8
 Jha2017_integrative_models	doi:10.1101/104869
@@ -193,6 +194,7 @@ Ragoza2016_protein	arxiv:1612.02751
 RAD2010_view_cc	doi:10.1145/1721654.1721672
 Radford_dcgan	arxiv:1511.06434v2
 Rajkomar2017_radiographs	doi:10.1007/s10278-016-9914-9
+Rakhlin2018_histology	doi:10.1101/259911
 Ramsundar2015_multitask_drug	arxiv:1502.02072
 Ranganath2016_deep	arxiv:1608.02158
 Raina2009_gpu	doi:10.1145/1553374.1553486


### PR DESCRIPTION
Following [the suggestion](https://github.com/greenelab/deep-review/pull/824#issuecomment-369744402), very short addition of 2 examples in Medical Imaging:
- TL + augmentations on very small data
- positive mining with no ground truth