### PR TITLE
Remove duplicate reference

### DIFF
--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -172,7 +172,7 @@ In recent work, the authors evaluated the extent to which deep learning methods 
 They found that performance was in line with, but lower than the best domain-specific method [@arxiv:1611.08373].
 This raises the possibility that deep learning may impact the field by reducing the researcher time and cost required to develop specific solutions, but it may not always lead to performance increases.
 
-In recent work, Yoon et al.[@tag:Yoon2016_cancer_reports] analyzed simple features using deep neural networks and found that the patterns recognized by the algorithms could be re-used across tasks.
+In recent work, Yoon et al. [@tag:Yoon2016_cancer_reports] analyzed simple features using deep neural networks and found that the patterns recognized by the algorithms could be re-used across tasks.
 Their aim was to analyze the free text portions of pathology reports to identify the primary site and laterality of tumors.
 The only features the authors supplied to the algorithms were unigrams (counts for single words) and bigrams (counts for two-word combinations) in a free text document.
 They subset the full set of words and word combinations to the 400 most common.

--- a/content/06.discussion.md
+++ b/content/06.discussion.md
@@ -298,7 +298,7 @@ Specialized hardware may be a difficult investment for those not solely interest
 
 Distributed computing is a general solution to intense computational requirements and has enabled many large-scale deep learning efforts.
 Some types of distributed computation [@tag:Mapreduce; @tag:Graphlab] are not suitable for deep learning [@tag:Dean2012_nips_downpour], but much progress has been made.
-There now exist a number of algorithms [@tag:Dean2012_nips_downpour; @tag:Dogwild; @tag:Sa2015_buckwild], tools [@tag:Moritz2015_sparknet; @tag:Meng2016_mllib; @tag:TensorFlow], and high-level libraries [@tag:Keras; @tag:Elephas] for deep learning in a distributed environment, and it is possible to train very complex networks with limited infrastructure [@tag:Coates2013_cots_hpc].
+There now exist a number of algorithms [@tag:Dean2012_nips_downpour; @tag:Sa2015_buckwild], tools [@tag:Moritz2015_sparknet; @tag:Meng2016_mllib; @tag:TensorFlow], and high-level libraries [@tag:Keras; @tag:Elephas] for deep learning in a distributed environment, and it is possible to train very complex networks with limited infrastructure [@tag:Coates2013_cots_hpc].
 Besides handling very large networks, distributed or parallelized approaches offer other advantages, such as improved ensembling [@tag:Sun2016_ensemble] or accelerated hyperparameter optimization [@tag:Bergstra2011_hyper; @tag:Bergstra2012_random].
 
 Cloud computing, which has already seen wide adoption in genomics [@tag:Schatz2010_dna_cloud], could facilitate easier sharing of the large datasets common to biology [@tag:Gerstein2016_scaling; @tag:Stein2010_cloud], and may be key to scaling deep learning.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -56,7 +56,6 @@ Ditzler3	doi:10.1109/TNB.2015.2461219
 Dhungel2015_struct_pred_mamm	doi:10.1007/978-3-319-24553-9_74
 Dhungel2016_mamm	doi:10.1007/978-3-319-46723-8_13
 Dhungel2017_mamm_min_interv	doi:10.1016/j.media.2017.01.009
-Dogwild	pmcid:PMC4907892
 Dream_tf_binding	url:https://www.synapse.org/#!Synapse:syn6131484/wiki/402026
 Dragonn	url:http://kundajelab.github.io/dragonn/
 Duvenaud2015_graph_conv	url:http://papers.nips.cc/paper/5954-convolutional-networks-on-graphs-for-learning-molecular-fingerprints
@@ -204,7 +203,7 @@ Roth2015_view_agg_cad	doi:10.1109/TMI.2015.2482920
 Romero2017_diet	url:https://openreview.net/pdf?id=Sk-oDY9ge
 Rosenberg2015_synthetic_seqs	doi:10.1016/j.cell.2015.09.054
 Russakovsky2015_imagenet	doi:10.1007/s11263-015-0816-y
-Sa2015_buckwild	arxiv:1506.06438
+Sa2015_buckwild	pmcid:PMC4907892
 Salzberg	doi:10.1186/1471-2105-11-544
 Schatz2010_dna_cloud	doi:10.1038/nbt0710-691
 Schmidhuber2014_dnn_overview	doi:10.1016/j.neunet.2014.09.003


### PR DESCRIPTION
The `Dogwild` and `Sa2015_buckwild` tags pointed to different versions of the same reference.