### PR TITLE
Specify white background for figures

### DIFF
--- a/content/02.intro.md
+++ b/content/02.intro.md
@@ -48,7 +48,7 @@ In the case of this example, each input node is only connected to hidden nodes a
 Autoencoder: a type of MLP in which the neural network is trained to produce an output that matches the input to the network.
 RNN: a deep recurrent neural network is used to allow the neural network to retain memory over time or sequential inputs.
 This figure was inspired by the [Neural Network Zoo](http://www.asimovinstitute.org/neural-network-zoo/) by Fjodor Van Veen.
-](https://user-images.githubusercontent.com/542643/34995383-52363dc0-faa4-11e7-8cdd-47966c1a2a0f.png){#fig:nn-petting-zoo}
+](https://user-images.githubusercontent.com/542643/34995383-52363dc0-faa4-11e7-8cdd-47966c1a2a0f.png){#fig:nn-petting-zoo .white}
 
 This review discusses recent work in the biomedical domain, and most successful applications select neural network architectures that are well suited to the problem at hand.
 We sketch out a few simple example architectures in Figure @fig:nn-petting-zoo.

--- a/content/03.categorize.md
+++ b/content/03.categorize.md
@@ -123,7 +123,7 @@ The main tasks in biological and clinical text mining include, but are not limit
 Deep learning is appealing in this domain because of its competitive performance versus traditional methods and ability to overcome challenges in feature engineering.
 Relevant applications can be stratified by the application domain (biomedical literature vs. clinical notes) and the actual task (e.g. concept or relation extraction).
 
-![Deep learning applications, tasks, and models based on NLP perspectives.](images/biotm.png){#fig:biotm width="100%"}
+![Deep learning applications, tasks, and models based on NLP perspectives.](images/biotm.png){#fig:biotm .white width="100%"}
 
 Named entity recognition (NER) is a task of identifying text spans that refer to a biological concept of a specific class, such as disease or chemical, in a controlled vocabulary or ontology.
 NER is often needed as a first step in many complex text mining systems.


### PR DESCRIPTION
See lightbox in [this version](https://greenelab.github.io/deep-review/v/61ea1fe8e49fbbe5adde8917f3159490a767626d/):

![image](https://user-images.githubusercontent.com/1117703/54834765-36857780-4c97-11e9-8d75-c026ad4c138d.png)

Specifying the `white` HTML class will add a white background so the transparency won't be a problem in lightbox mode.