### PR TITLE
add note about revisions/new authors

### DIFF
--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -4,7 +4,9 @@
   Pandoc automatically inserts title from metadata.yaml, so it is not included in this template.
 ##}
 
-_A published version of this manuscript from 04 April 2018 is available at <https://doi.org/10.1098/rsif.2017.0387>. An effort is underway to update the manuscript to capture the state of the field in 2019. New authors and links to new sections are available in [GitHub Issue #959](https://github.com/greenelab/deep-review/issues/959)._
+_A published version of this manuscript from 04 April 2018 is available at <https://doi.org/10.1098/rsif.2017.0387>.
+An effort is underway to update the manuscript to capture the state of the field in 2019.
+New authors and links to new sections are available in [GitHub Issue #959](https://github.com/greenelab/deep-review/issues/959)._
 
 {## Template to insert build date and source ##}
 <small><em>

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -4,7 +4,7 @@
   Pandoc automatically inserts title from metadata.yaml, so it is not included in this template.
 ##}
 
-_The published version of this manuscript is available at <https://doi.org/10.1098/rsif.2017.0387>_.
+_A published version of this manuscript from 04 April 2018 is available at <https://doi.org/10.1098/rsif.2017.0387>. An effort is underway to update the manuscript to capture the state of the field in 2019. New authors and links to new sections are available in [GitHub Issue #959](https://github.com/greenelab/deep-review/issues/959)._
 
 {## Template to insert build date and source ##}
 <small><em>
@@ -31,6 +31,7 @@ on {{date}}.
 
 <sup>☯</sup> --- Author order was determined with a randomized algorithm<br>
 <sup>†</sup> --- To whom correspondence should be addressed: gitter@biostat.wisc.edu (A.G.) and greenescientist@gmail.com (C.S.G.)
+
 <small>
 
 {% for affiliation in affiliations %}


### PR DESCRIPTION
We now have contributions that add new sections. We should let readers know that there is new material here and that there are new contributors.