### PR TITLE
Add Manubot reference

### DIFF
--- a/content/08.methods.md
+++ b/content/08.methods.md
@@ -7,6 +7,7 @@ Hence, diverse expertise was required to provide a forward-looking perspective.
 Accordingly, we collaboratively wrote this review in the open, enabling anyone with expertise to contribute.
 We wrote the manuscript in markdown and tracked changes using git.
 Contributions were handled through GitHub, with individuals submitting "pull requests" to suggest additions to the manuscript.
+This collaborative writing approach was later generalized into the Manubot workflow and software [@doi:10.1371/journal.pcbi.1007128].
 
 To facilitate citation, we [defined](https://github.com/greenelab/deep-review/blob/master/USAGE.md#citations) a markdown citation syntax.
 We supported citations to the following identifier types (in order of preference): DOIs, PubMed Central IDs, PubMed IDs, arXiv IDs, and URLs.


### PR DESCRIPTION
I'm adding the Manubot reference to alert readers to the more complete description of our collaborative writing process.  Potentially this entire Methods section could be substantially shortened and replaced with the Manubot reference.