### PR TITLE
Correct Caruana pneumonia reference

### DIFF
--- a/content/06.discussion.md
+++ b/content/06.discussion.md
@@ -114,7 +114,7 @@ First, a model that achieves breakthrough performance may have identified patter
 However, this would not be possible if the model is a black box.
 Second, interpretability is important for trust.
 If a model is making medical diagnoses, it is important to ensure the model is making decisions for reliable reasons and is not focusing on an artifact of the data.
-A motivating example of this can be found in Ba and Caruana [@tag:Caruana2014_need], where a model trained to predict the likelihood of death from pneumonia assigned lower risk to patients with asthma, but only because such patients were treated as higher priority by the hospital.
+A motivating example of this can be found in Caruana et al. [@tag:Caruana2015_intelligible], where a model trained to predict the likelihood of death from pneumonia assigned lower risk to patients with asthma, but only because such patients were treated as higher priority by the hospital.
 In the context of deep learning, understanding the basis of a model's output is particularly important as deep learning models are unusually susceptible to adversarial examples [@tag:Nguyen2014_adversarial] and can output confidence scores over 99.99% for samples that resemble pure noise.
 
 As the concept of interpretability is quite broad, many methods described as improving the interpretability of deep learning models take disparate and often complementary approaches.

--- a/content/citation-tags.tsv
+++ b/content/citation-tags.tsv
@@ -30,7 +30,7 @@ Buggenthin2017_imaged_lineage	doi:10.1038/nmeth.4182
 Burlina2016_amd	doi:10.1109/ISBI.2016.7493240
 Chatterjee2018	arxiv:1807.09617
 Caruana2014_need	arxiv:1312.6184
-Caruana2015_intelligible	url:https://dl.acm.org/citation.cfm?id=2788613
+Caruana2015_intelligible	doi:10.1145/2783258.2788613
 Chaudhary2017_multiom_liver_cancer	doi:10.1101/114892
 Che2015_distill	arxiv:1512.03542
 Che2016_rnn	arxiv:1606.01865


### PR DESCRIPTION
Closes #975.

Thanks again @smthomas-sci.  This looks like the reference that was originally intended:

> patients with a history of asthma who presented with pneumonia usually were admitted not only to
the hospital but directly to the ICU (Intensive Care Unit)

>The GA2M model has found the same pattern discovered back then: that having asthma lowers the risk of dying from pneumonia