### PR TITLE
Upgrade rootstock on 2019-08-31

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,57 @@
+# See https://www.appveyor.com/docs/getting-started-with-appveyor-for-linux/
+skip_branch_with_pr: true
+
+# Enable 'Do not build on "Push" events' in the AppVeyor project settings
+# to only build commits from pull requests
+branches:
+  only:
+    - master
+
+# Only run AppVeyor on commits that modify at least one of the following files
+# Delete these lines to run AppVeyor on all master branch commits
+only_commits:
+  files:
+    - .appveyor.yml
+    - build/
+    - ci/install.sh
+    - content/
+
+image: ubuntu
+services:
+  - docker
+
+install:
+  # Create the message with the triggering commit before install so it is
+  # available if the build fails
+  - TRIGGERING_COMMIT=${APPVEYOR_PULL_REQUEST_HEAD_COMMIT:-APPVEYOR_REPO_COMMIT}
+  - appveyor AddMessage "commit $TRIGGERING_COMMIT"
+  - source ci/install.sh
+    
+test_script:
+  - bash build/build.sh
+  - MANUSCRIPT_FILENAME=manuscript-$APPVEYOR_BUILD_VERSION-${TRIGGERING_COMMIT:0:7}.pdf
+  - cp output/manuscript.pdf $MANUSCRIPT_FILENAME
+  - appveyor PushArtifact $MANUSCRIPT_FILENAME
+
+build: off
+
+cache:
+  - ci/cache
+
+on_success:
+  - echo "Artifacts available from $APPVEYOR_URL/project/$APPVEYOR_ACCOUNT_NAME/$APPVEYOR_PROJECT_SLUG/builds/$APPVEYOR_BUILD_ID/artifacts"
+  - echo "Updated PDF available from $APPVEYOR_URL/api/buildjobs/$APPVEYOR_JOB_ID/artifacts/$MANUSCRIPT_FILENAME"
+
+# The following lines can be safely deleted, which will disable AppVeyorBot
+# notifications in GitHub pull requests
+# Notifications use Mustache templates http://mustache.github.io/mustache.5.html
+# See https://www.appveyor.com/docs/notifications/#customizing-message-template
+# for available variables
+notifications:
+  - provider: GitHubPullRequest
+    template: "AppVeyor [build {{buildVersion}}]({{buildUrl}})
+      {{#jobs}}{{#messages}} for {{message}} by @{{&commitAuthorUsername}} {{/messages}}{{/jobs}}
+      {{#passed}} is now complete.{{/passed}}
+      {{#failed}} failed.{{/failed}}
+      {{#jobs}}{{#artifacts}} The rendered manuscript from this build is temporarily available for download at
+      [`{{fileName}}`]({{permalink}}).{{/artifacts}}{{/jobs}}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,17 @@ services:
 branches:
   only:
     - master
-before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh
-    --output-document miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - source $HOME/miniconda/etc/profile.d/conda.sh
-  - hash -r
-  - conda config
-    --set always_yes yes
-    --set changeps1 no
 install:
-  - conda env create --quiet --file build/environment.yml
-  - conda list --name manubot
-  - conda activate manubot
+  - source ci/install.sh
 script:
-  - sh build/build.sh
+  - bash build/build.sh
 cache:
   directories:
     - ci/cache
-after_success:
-  - test $TRAVIS_BRANCH = "master" &&
-    test $TRAVIS_EVENT_TYPE = "push" &&
-    sh ci/deploy.sh
+deploy:
+  provider: script
+  script: bash -o xtrace ci/deploy.sh
+  skip_cleanup: true
+  on:
+    branch: master
+    condition: $TRAVIS_EVENT_TYPE = "push"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The directories are as follows:
 
 + [`content`](content) contains the manuscript source, which includes markdown files as well as inputs for citations and references.
   See [`USAGE.md`](USAGE.md) for more information.
-+ [`output`](output) contains the outputs (generated files) from the manubot including the resulting manuscripts.
++ [`output`](output) contains the outputs (generated files) from Manubot including the resulting manuscripts.
   You should not edit these files manually, because they will get overwritten.
 + [`webpage`](webpage) is a directory meant to be rendered as a static webpage for viewing the HTML manuscript.
 + [`build`](build) contains commands and tools for building the manuscript.
@@ -95,23 +95,27 @@ The directories are as follows:
 
 ### Local execution
 
-To run the Manubot locally, install the [conda](https://conda.io) environment as described in [`build`](build).
-Then, you can build the manuscript on POSIX systems by running the following commands.
+The easiest way to run Manubot is to use [continuous integration](#continuous-integration) to rebuild the manuscript when the content changes.
+If you want to build a Manubot manuscript locally, install the [conda](https://conda.io) environment as described in [`build`](build).
+Then, you can build the manuscript on POSIX systems by running the following commands from this root directory.
 
 ```sh
 # Activate the manubot conda environment (assumes conda version >= 4.4)
 conda activate manubot
 
 # Build the manuscript, saving outputs to the output directory
-sh build/build.sh
+bash build/build.sh
 
 # At this point, the HTML & PDF outputs will have been created. The remaining
 # commands are for serving the webpage to view the HTML manuscript locally.
+# This is required to view local images in the HTML output.
 
 # Configure the webpage directory
 python build/webpage.py
 
-# View the manuscript locally at http://localhost:8000/
+# You can now open the manuscript webpage/index.html in a web browser.
+# Alternatively, open a local webserver at http://localhost:8000/ with the
+# following commands.
 cd webpage
 python -m http.server
 ```
@@ -120,7 +124,7 @@ Sometimes it's helpful to monitor the content directory and automatically rebuil
 The following command, while running, will trigger both the `build.sh` and `webpage.py` scripts upon content changes:
 
 ```sh
-sh build/autobuild.sh
+bash build/autobuild.sh
 ```
 
 ### Continuous Integration

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,8 @@
 # Manubot usage guidelines
 
 This repository uses [Manubot](https://manubot.org) to automatically produce a manuscript from the source in the [`content`](content) directory.
+Check out the [Manubot catalog](https://manubot.org/catalog/) for examples of what is possible when writing with Manubot.
+Try editing the [demo manuscript](https://github.com/manubot/try-manubot) to quickly test Manubot formatting and citations.
 
 ## Manubot markdown
 
@@ -186,39 +188,30 @@ funders: GBMF4552  # optional
 
 Note that `affiliations` should be a list to allow for multiple affiliations per author.
 
+## Custom formatting
+
+Modifying the manuscript formatting requires modifying the CSS in the file [`build/themes/default.html`](build/themes/default.html).
+Common formatting changes, such as [font size](https://github.com/manubot/rootstock/issues/239) and [double spacing](https://github.com/manubot/rootstock/issues/244), can be found by searching the [Rootstock issues](https://github.com/manubot/rootstock/issues).
+Open a [new issue](https://github.com/manubot/rootstock/issues/new) if you have a new formatting question.
+
+Changing the citation style or which interactive HTML plugins are loaded requires editing the build script [`build/build.sh`](build/build.sh).
+The citation style is determined by the Citation Style Language file specified by `CSL_PATH`.
+It can be changed to use other existing styles as [described here](https://github.com/manubot/rootstock/issues/242#issuecomment-507688339).
+
 ## Manubot feedback
 
 If you experience any issues with the Manubot or would like to contribute to its source code, please visit [`manubot/manubot`](https://github.com/manubot/manubot) or [`manubot/rootstock`](https://github.com/manubot/rootstock).
 
-## Examples
-
-For additional examples, check out existing manuscripts that use the Manubot (some of which are still in progress):
-
-+ Satoshi Nakamoto's Bitcoin Whitepaper ([source](https://github.com/dhimmel/bitcoin-whitepaper/), [manuscript](https://dhimmel.github.io/bitcoin-whitepaper/), [commentary](https://steemit.com/manubot/@dhimmel/how-i-used-the-manubot-to-reproduce-the-bitcoin-whitepaper))
-+ The Sci-Hub Coverage Study ([source](https://github.com/greenelab/scihub-manuscript), [manuscript](https://greenelab.github.io/scihub-manuscript/))
-+ The GimmeMotifs manscript on transcription factor motif analysis ([source](https://github.com/simonvh/gimmemotifs-manuscript), [manuscript](https://simonvh.github.io/gimmemotifs-manuscript/manuscript.pdf))
-+ A Report for the Vagelos Scholars Program by Michael Zietz ([source](https://github.com/zietzm/Vagelos2017), [manuscript](https://zietzm.github.io/Vagelos2017/))
-+ The Deep Review ([source](https://github.com/greenelab/deep-review), [manuscript](https://greenelab.github.io/deep-review/))
-+ Ten Quick Tips for Deep Learning ([source](https://github.com/Benjamin-Lee/deep-rules), [manuscript](https://benjamin-lee.github.io/deep-rules/))
-+ The Meta Review ([source](https://github.com/greenelab/meta-review), [manuscript](https://greenelab.github.io/meta-review/))
-+ A review of Network Methods for Multiomic Data Integration ([source](https://github.com/zietzm/integration-review), [manuscript](https://zietzm.github.io/integration-review/))
-+ The Project Rephetio Manuscript ([source](https://github.com/dhimmel/rephetio-manuscript/), [manuscript](https://dhimmel.github.io/rephetio-manuscript/))
-+ A Literature Review for Project Planning by David Slochower ([source](https://github.com/slochower/synthetic-motor-literature), [manuscript](https://slochower.github.io/synthetic-motor-literature/))
-+ The TFSEE Manuscript by Venkat Malladi et al. ([source](https://github.com/vsmalladi/tfsee-manuscript), [manuscript](https://vsmalladi.github.io/tfsee-manuscript/))
-+ Creating a Global Emissions Timeseries dataset by Robert Gieseke et al. ([source](https://github.com/openclimatedata/global-emissions), [manuscript](https://openclimatedata.github.io/global-emissions/))
-+ The yt 3.0 methods paper ([source](https://github.com/yt-project/yt-3.0-paper), [manuscript](https://yt-project.github.io/yt-3.0-paper/))
-+ The TPOT-DS Manuscript (includes Hypothesis annotations, [source](https://github.com/trang1618/tpot-ds-ms), [manuscript](https://trang1618.github.io/tpot-ds-ms/))
-+ The Manubot 2018 Development Proposal ([source](https://github.com/greenelab/manufund-2018), [manuscript](https://greenelab.github.io/manufund-2018/))
-
-If you are using the Manubot, feel free to submit a pull request to add your manuscript to the list above.
-
 ## Citing Manubot
 
-To cite the Manubot project or for more information on its design and history, see `@url:https://greenelab.github.io/meta-review/`:
+To cite the Manubot project or for more information on its design and history, see `@doi:10.1371/journal.pcbi.1007128`:
 
 > **Open collaborative writing with Manubot**<br>
 Daniel S. Himmelstein, Vincent Rubinetti, David R. Slochower, Dongbo Hu, Venkat S. Malladi, Casey S. Greene, Anthony Gitter<br>
-_Manubot Preprint_ (2019) <https://greenelab.github.io/meta-review/>
+*PLOS Computational Biology* (2019-06-24) <https://doi.org/c7np><br>
+DOI: [10.1371/journal.pcbi.1007128](https://doi.org/10.1371/journal.pcbi.1007128) · PMID: [31233491](https://www.ncbi.nlm.nih.gov/pubmed/31233491)
+
+The Manubot version of this manuscript is available at <https://greenelab.github.io/meta-review/>.
 
 ## Acknowledgments
 

--- a/build/README.md
+++ b/build/README.md
@@ -4,10 +4,10 @@
 `sh build/build.sh` should be executed from the root directory of the repository.
 By default, `build.sh` creates HTML and PDF outputs.
 However, setting the `BUILD_PDF` environment variable to `false` will suppress PDF output.
-For example, run local builds using the command `BUILD_PDF=false sh build/build.sh`.
+For example, run local builds using the command `BUILD_PDF=false bash build/build.sh`.
 
 To build a DOCX file of the manuscript, set the `BUILD_DOCX` environment variable to `true`.
-For example, use the command `BUILD_DOCX=true sh build/build.sh`.
+For example, use the command `BUILD_DOCX=true bash build/build.sh`.
 To export DOCX for all Travis builds, set a [Travis environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).
 Currently, equation numbers via `pandoc-eqnos` are not supported for DOCX output.
 There is varying support for embedding images in DOCX output.
@@ -17,7 +17,7 @@ Please reference [Pull Request #40](https://github.com/manubot/rootstock/pull/40
 
 Note: currently, **Windows is not supported**.
 
-Install or update the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running:
+Install or update the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running the following commands from this directory:
 
 ```sh
 # If the manubot environment already exists, remove it first
@@ -33,3 +33,16 @@ However, it will fail on Windows due to the [`pango`](https://anaconda.org/conda
 
 Because the build process is dependent on having the appropriate version of the `manubot` Python package, it is necessary to use the version specified in `environment.yml`.
 The latest `manubot` release on PyPI may not be compatible with the latest version of this rootstock repository.
+
+## Building PDFs
+
+If Docker is available, `build.sh` uses the [Athena](https://www.athenapdf.com/) [Docker image](https://hub.docker.com/r/arachnysdocker/athenapdf) to build the PDF.
+Otherwise, `build.sh` uses [WeasyPrint](https://weasyprint.org/) to build the PDF.
+It is common for WeasyPrint to generate many warnings and errors that can be safely ignored.
+Examples are shown below:
+```
+WARNING: Ignored `pointer-events: none` at 3:16, unknown property.
+WARNING: Ignored `font-display:auto` at 1:53114, descriptor not supported.
+ERROR: Failed to load font at "https://use.fontawesome.com/releases/v5.7.2/webfonts/fa-brands-400.eot#iefix"
+WARNING: Expected a media type, got only/**/screen
+```

--- a/build/autobuild.sh
+++ b/build/autobuild.sh
@@ -1,6 +1,9 @@
-# Automatically rebuild mansucript outputs and the webpage when content changes
-# Depends on watchdog https://github.com/gorakhargosh/watchdog
+#!/usr/bin/env bash
+
+## autobuild.sh: automatically rebuild mansucript outputs and the webpage when content changes
+## Depends on watchdog https://github.com/gorakhargosh/watchdog
+
 watchmedo shell-command \
   --wait \
-  --command='sh build/build.sh && python build/webpage.py' \
+  --command='bash build/build.sh && python build/webpage.py' \
   content

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,10 @@
-set -o errexit
+#!/usr/bin/env bash
+
+## build.sh: compile manuscript outputs from content using Manubot and Pandoc
+
+set -o errexit \
+    -o nounset \
+    -o pipefail
 
 # Set timezone used by Python for setting the manuscript's date
 export TZ=Etc/UTC
@@ -6,7 +12,7 @@ export TZ=Etc/UTC
 export LC_ALL=en_US.UTF-8
 
 # Generate reference information
-echo "Retrieving and processing reference metadata"
+echo >&2 "Retrieving and processing reference metadata"
 manubot process \
   --content-directory=content \
   --output-directory=output \
@@ -23,15 +29,15 @@ mkdir -p output
 
 # Create HTML output
 # http://pandoc.org/MANUAL.html
-echo "Exporting HTML manuscript"
+echo >&2 "Exporting HTML manuscript"
 pandoc --verbose \
   --from=markdown \
   --to=html5 \
   --filter=pandoc-fignos \
   --filter=pandoc-eqnos \
   --filter=pandoc-tablenos \
-  --bibliography=$BIBLIOGRAPHY_PATH \
-  --csl=$CSL_PATH \
+  --bibliography="$BIBLIOGRAPHY_PATH" \
+  --csl="$CSL_PATH" \
   --metadata link-citations=true \
   --include-after-body=build/themes/default.html \
   --include-after-body=build/plugins/table-scroll.html \
@@ -48,14 +54,15 @@ pandoc --verbose \
   --include-after-body=build/plugins/hypothesis.html \
   --include-after-body=build/plugins/analytics.html \
   --output=output/manuscript.html \
-  $INPUT_PATH
+  "$INPUT_PATH"
 
 # Return null if docker command is missing, otherwise return path to docker
 DOCKER_EXISTS="$(command -v docker || true)"
 
 # Create PDF output (unless BUILD_PDF environment variable equals "false")
-if [ "$BUILD_PDF" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then
-  echo "Exporting PDF manuscript using WeasyPrint"
+# If Docker is not available, use WeasyPrint to create PDF
+if [ "${BUILD_PDF:-}" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then
+  echo >&2 "Exporting PDF manuscript using WeasyPrint"
   if [ -L images ]; then rm images; fi  # if images is a symlink, remove it
   ln -s content/images
   pandoc \
@@ -66,49 +73,55 @@ if [ "$BUILD_PDF" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then
     --filter=pandoc-fignos \
     --filter=pandoc-eqnos \
     --filter=pandoc-tablenos \
-    --bibliography=$BIBLIOGRAPHY_PATH \
-    --csl=$CSL_PATH \
+    --bibliography="$BIBLIOGRAPHY_PATH" \
+    --csl="$CSL_PATH" \
     --metadata link-citations=true \
     --webtex=https://latex.codecogs.com/svg.latex? \
     --include-after-body=build/themes/default.html \
     --output=output/manuscript.pdf \
-    $INPUT_PATH
+    "$INPUT_PATH"
   rm images
 fi
 
-# Create PDF output (unless BUILD_PDF environment variable equals "false")
-if [ "$BUILD_PDF" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
-  echo "Exporting PDF manuscript using Docker + Athena"
+# If Docker is available, use athenapdf to create PDF
+if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
+  echo >&2 "Exporting PDF manuscript using Docker + Athena"
+  if [ "${CI:-}" = "true" ]; then
+    # Incease --delay for CI builds to ensure the webpage fully renders, even when the CI server is under high load.
+    # Local builds default to a shorter --delay to minimize runtime, assuming proper rendering is less crucial.
+    MANUBOT_ATHENAPDF_DELAY="${MANUBOT_ATHENAPDF_DELAY:-5000}"
+    echo >&2 "Continuous integration build detected. Setting athenapdf --delay=$MANUBOT_ATHENAPDF_DELAY"
+  fi
   if [ -d output/images ]; then rm -rf output/images; fi  # if images is a directory, remove it
   cp -R -L content/images output/
   docker run \
     --rm \
     --shm-size=1g \
-    --volume=`pwd`/output:/converted/ \
+    --volume="$(pwd)/output:/converted/" \
     --security-opt=seccomp:unconfined \
     arachnysdocker/athenapdf:2.16.0 \
     athenapdf \
-    --delay=2000 \
+    --delay=${MANUBOT_ATHENAPDF_DELAY:-1100} \
     manuscript.html manuscript.pdf
   rm -rf output/images
 fi
 
 # Create DOCX output (if BUILD_DOCX environment variable equals "true")
-if [ "$BUILD_DOCX" = "true" ]; then
-  echo "Exporting Word Docx manuscript"
+if [ "${BUILD_DOCX:-}" = "true" ]; then
+  echo >&2 "Exporting Word Docx manuscript"
   pandoc --verbose \
     --from=markdown \
     --to=docx \
     --filter=pandoc-fignos \
     --filter=pandoc-eqnos \
     --filter=pandoc-tablenos \
-    --bibliography=$BIBLIOGRAPHY_PATH \
-    --csl=$CSL_PATH \
+    --bibliography="$BIBLIOGRAPHY_PATH" \
+    --csl="$CSL_PATH" \
     --metadata link-citations=true \
     --reference-doc=build/themes/default.docx \
     --resource-path=.:content \
     --output=output/manuscript.docx \
-    $INPUT_PATH
+    "$INPUT_PATH"
 fi
 
-echo "Build complete"
+echo >&2 "Build complete"

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -7,19 +7,19 @@ dependencies:
   - cffi=1.12.3
   - ghp-import=0.5.5
   - jinja2=2.10
-  - jsonschema=3.0.1
-  - pandas=0.24.2
-  - pandoc=2.7.2
+  - jsonschema=3.0.2
+  - pandas=0.25.0
+  - pandoc=2.7.3
   - pango=1.40.14
   - pip=19.1
-  - psutil=5.6.2
+  - psutil=5.6.3
   - python=3.6.7
   - pyyaml=5.1
   - requests=2.22.0
-  - watchdog=0.8.3
+  - watchdog=0.9.0
   - pip:
     - errorhandler==2.0.1
-    - git+https://github.com/manubot/manubot@2a99f4af4a352d2e082988d364e01e2e2809a87b
+    - git+https://github.com/manubot/manubot@1b885c614634d6e88565ebcf5052b6884132ab32
     - jsonref==0.2
     - opentimestamps-client==0.6.0
     - opentimestamps==0.3.0
@@ -27,7 +27,7 @@ dependencies:
     - pandoc-fignos==1.4.2
     - pandoc-tablenos==1.4.2
     - pandoc-xnos==1.2.0
-    - pybase62==0.4.0
+    - pybase62==0.4.1
     - pysha3==1.0.2
     - python-bitcoinlib==0.9.0
     - requests-cache==0.5.0

--- a/build/plugins/math.html
+++ b/build/plugins/math.html
@@ -4,7 +4,8 @@
     MathJax.Hub.Config({
         "CommonHTML": { linebreaks: { automatic: true } },
         "HTML-CSS": { linebreaks: { automatic: true } },
-        "SVG": { linebreaks: { automatic: true } }
+        "SVG": { linebreaks: { automatic: true } },
+        "fast-preview": { disabled: true }
     });
 </script>
 

--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -1,5 +1,5 @@
-# SSH private key
-deploy.key
+# SSH public and private keys
+deploy.key*
 
-# Output from travis encrypt-file
+# Output from travis encrypt-file (legacy)
 travis-encrypt-file.log

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,29 +1,8 @@
-# Continuous integration / analysis directory
+# Continuous integration tools
 
-[![Build Status](https://travis-ci.org/greenelab/deep-review.svg?branch=master)](https://travis-ci.org/greenelab/deep-review)
+This directory contains tools and files for continuous integration (CI).
+Specifically, [`deploy.sh`](deploy.sh) runs on successful `master` branch builds that are not pull requests.
+The contents of `../webpage` are committed to the `gh-pages` branch.
+The contents of `../output` are committed to the `output` branch.
 
-This repository uses [continuous analysis](https://doi.org/10.1101/056473 "Reproducible Computational Workflows with Continuous Analysis") to create the manuscript and commit it back to GitHub.
-[`deploy.sh`](deploy.sh) runs on successful `master` branch builds that are not pull requests.
-The contents of `/output` are committed to the `gh-pages` branch.
-The contents of `/references/generated` are committed to the `references` branch.
-
-## Generating the GitHub deploy key
-
-To generate and configure the GitHub SSH deploy key, run the following commands from this directory.
-
-```sh
-# Generate a new SSH key
-ssh-keygen \
-  -t rsa \
-  -b 4096 \
-  -C "travis@travis-ci.com" \
-  -N "" \
-  -f deploy.key
-# Add deploy.key.pub to GitHub under the repository's settings
-# see https://developer.github.com/guides/managing-deploy-keys/#deploy-keys
-
-# Encrypt and upload key to Travis CI.
-# See https://docs.travis-ci.com/user/encrypting-files/
-travis encrypt-file deploy.key
-# Modify the returned command to decrypt the key in ci/deploy.sh
-```
+For more information on the CI implementation, see the [Travis CI configuration](../.travis.yml) and the CI setup documentation in `SETUP.md`.

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,28 +1,44 @@
-# Exit on errors
-set -o errexit
+#!/usr/bin/env bash
+
+## deploy.sh: run during a Travis CI build to deploy manuscript outputs to the output and gh-pages branches on GitHub.
+
+# Set options for extra caution & debugging
+set -o errexit \
+    -o nounset \
+    -o pipefail
 
 # Add commit hash to the README
-export OWNER_NAME=`dirname $TRAVIS_REPO_SLUG`
-export REPO_NAME=`basename $TRAVIS_REPO_SLUG`
+OWNER_NAME="$(dirname "$TRAVIS_REPO_SLUG")"
+REPO_NAME="$(basename "$TRAVIS_REPO_SLUG")"
+export OWNER_NAME REPO_NAME
 envsubst < webpage/README.md > webpage/README-complete.md
 mv webpage/README-complete.md webpage/README.md
 
 # Configure git
 git config --global push.default simple
-git config --global user.email `git log --max-count=1 --format='%ae'`
-git config --global user.name "`git log --max-count=1 --format='%an'`"
-git checkout $TRAVIS_BRANCH
-git remote set-url origin git@github.com:$TRAVIS_REPO_SLUG.git
+git config --global user.email "$(git log --max-count=1 --format='%ae')"
+git config --global user.name "$(git log --max-count=1 --format='%an')"
+git checkout "$TRAVIS_BRANCH"
+git remote set-url origin "git@github.com:$TRAVIS_REPO_SLUG.git"
 
 # Decrypt and add SSH key
+eval "$(ssh-agent -s)"
+(
+set +o xtrace  # disable xtrace in subshell for private key operations
+if [ -v MANUBOT_SSH_PRIVATE_KEY ]; then
+  base64 --decode <<< "$MANUBOT_SSH_PRIVATE_KEY" | ssh-add -
+else
+echo "DeprecationWarning: Loading deploy.key from an encrypted file.
+In the future, using the MANUBOT_SSH_PRIVATE_KEY environment variable may be required."
 openssl aes-256-cbc \
   -K $encrypted_0dd7e5f24ac8_key \
   -iv $encrypted_0dd7e5f24ac8_iv \
   -in ci/deploy.key.enc \
   -out ci/deploy.key -d
-eval `ssh-agent -s`
 chmod 600 ci/deploy.key
 ssh-add ci/deploy.key
+fi
+)
 
 # Fetch and create gh-pages and output branches
 # Travis does a shallow and single branch git clone
@@ -33,26 +49,24 @@ git fetch origin gh-pages:gh-pages output:output
 python build/webpage.py \
   --no-ots-cache \
   --checkout=gh-pages \
-  --version=$TRAVIS_COMMIT
+  --version="$TRAVIS_COMMIT"
 
 # Generate OpenTimestamps
-ots stamp webpage/v/$TRAVIS_COMMIT/index.html
-if [ "$BUILD_PDF" != "false" ]; then
-  ots stamp webpage/v/$TRAVIS_COMMIT/manuscript.pdf
+ots stamp "webpage/v/$TRAVIS_COMMIT/index.html"
+if [ "${BUILD_PDF:-}" != "false" ]; then
+  ots stamp "webpage/v/$TRAVIS_COMMIT/manuscript.pdf"
 fi
 
 # Commit message
 MESSAGE="\
-`git log --max-count=1 --format='%s'`
+$(git log --max-count=1 --format='%s') [ci skip]
 
 This build is based on
 https://github.com/$TRAVIS_REPO_SLUG/commit/$TRAVIS_COMMIT.
 
 This commit was created by the following Travis CI build and job:
-https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID
-https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID
-
-[ci skip]
+$TRAVIS_BUILD_WEB_URL
+$TRAVIS_JOB_WEB_URL
 
 The full commit message that triggered this build is copied below:
 
@@ -68,6 +82,7 @@ ghp-import \
 
 # Deploy the webpage directory to gh-pages
 ghp-import \
+  --no-jekyll \
   --follow-links \
   --push \
   --branch=gh-pages \

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+## install.sh: run during a Travis CI or AppVeyor build to install the conda environment.
+
+# Set options for extra caution & debugging
+set -o errexit \
+    -o pipefail
+
+wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
+    --output-document miniconda.sh
+bash miniconda.sh -b -p $HOME/miniconda
+source $HOME/miniconda/etc/profile.d/conda.sh
+hash -r
+conda config \
+  --set always_yes yes \
+  --set changeps1 no
+conda env create --quiet --file build/environment.yml
+conda list --name manubot
+conda activate manubot

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,7 +6,7 @@
 set -o errexit \
     -o pipefail
 
-wget https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh \
+wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh \
     --output-document miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 source $HOME/miniconda/etc/profile.d/conda.sh

--- a/content/00.front-matter.md
+++ b/content/00.front-matter.md
@@ -11,8 +11,8 @@ New authors and links to new sections are available in [GitHub Issue #959](https
 {## Template to insert build date and source ##}
 <small><em>
 This manuscript
-{% if ci_source is defined -%}
-([permalink](https://{{ci_source.repo_owner}}.github.io/{{ci_source.repo_name}}/v/{{ci_source.commit}}/))
+{% if ci_source is defined and ci_source.manuscript_url is defined -%}
+([permalink]({{ci_source.manuscript_url}}))
 {% endif -%}
 was automatically generated
 {% if ci_source is defined -%}


### PR DESCRIPTION
These Manubot rootstock updates support optionally enabling pull request build previews with AppVeyor.  AppVeyor builds the manuscript pdf, and @AppVeyorBot comments in the pull request with a link to the manuscript.  This helps review changes like #976.  However, it creates more notifications.

I'm in favor of enabling AppVeyor on this repository.