### PR TITLE
Add date to competing interests statement

### DIFF
--- a/content/08.methods.md
+++ b/content/08.methods.md
@@ -49,6 +49,8 @@ A.K. is on the Advisory Board of Deep Genomics Inc.
 E.F. is a full-time employee of GlaxoSmithKline.
 The remaining authors have no competing interests to declare.
 
+The authors last reviewed and approved this competing interests statement on May 26, 2017.
+
 ### Acknowledgements
 
 We gratefully acknowledge Christof Angermueller, Kumardeep Chaudhary, Gökcen Eraslan, Mikael Huss, Bharath Ramsundar and Xun Zhu for their discussion of the manuscript and reviewed papers on GitHub.


### PR DESCRIPTION
This pull request implements @michaelmhoffman's [suggestion](https://twitter.com/michaelhoffman/status/1201612632026804224) to add the date the competing interests statement was last reviewed and approved.

The statement was originally added in #520 based on approvals in #518.