### PR TITLE
Randomize author order on CI builds

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,6 +11,9 @@ export TZ=Etc/UTC
 # Default Python to read/write text files using UTF-8 encoding
 export LC_ALL=en_US.UTF-8
 
+# Randomize authors in metadata.yaml
+python build/randomize-authors.py --shuffle --only-on-ci
+
 # Generate reference information
 echo >&2 "Retrieving and processing reference metadata"
 manubot process \

--- a/build/randomize-authors.py
+++ b/build/randomize-authors.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import pathlib
 import random
 import subprocess
@@ -7,6 +6,7 @@ import sys
 
 import yaml
 from manubot.util import read_serialized_data
+from manubot.process.ci import get_continuous_integration_parameters
 
 
 def parse_args():
@@ -29,7 +29,8 @@ def parse_args():
     args = parser.parse_args()
     vars(args)["execute"] = True
     if args.only_on_ci:
-        vars(args)["execute"] = os.environ.get("CI", "false").lower() == "true"
+        ci_params = get_continuous_integration_parameters()
+        vars(args)["execute"] = bool(ci_params)
     return args
 
 

--- a/build/randomize-authors.py
+++ b/build/randomize-authors.py
@@ -1,0 +1,82 @@
+import argparse
+import os
+import pathlib
+import random
+import subprocess
+import sys
+
+import yaml
+from manubot.util import read_serialized_data
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Randomize metadata.authors. Ovewrites metadata.yaml"
+    )
+    parser.add_argument(
+        "--path", default="content/metadata.yaml", help="path to metadata.yaml"
+    )
+    parser.add_argument(
+        "--shuffle",
+        action="store_true",
+        help="shuffle authors using HEAD commit as random seed",
+    )
+    parser.add_argument(
+        "--only-on-ci",
+        action="store_true",
+        help="do nothing if CI environment variable is not true",
+    )
+    args = parser.parse_args()
+    vars(args)["execute"] = True
+    if args.only_on_ci:
+        vars(args)["execute"] = os.environ.get("CI", "false").lower() == "true"
+    return args
+
+
+def shuffle(x, seed=None):
+    """
+    shuffle x in-place using seed
+    """
+    random.Random(seed).shuffle(x)
+
+
+def get_head_commit():
+    args = ["git", "rev-parse", "HEAD"]
+    try:
+        return subprocess.check_output(args)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def dump_yaml(obj, path):
+    path = pathlib.Path(path)
+    sys.stderr.write(f"Dumping YAML to {path}\n")
+    with path.open("w", encoding="utf-8") as write_file:
+        yaml.dump(
+            obj,
+            write_file,
+            # default_flow_style=False,
+            explicit_start=True,
+            explicit_end=True,
+            width=float("inf"),
+            sort_keys=False,
+            allow_unicode=True,
+        )
+        write_file.write("\n")
+
+
+if __name__ == "__main__":
+    """
+    Alternative to https://github.com/manubot/manubot/pull/214
+    """
+    args = parse_args()
+    if not args.execute:
+        sys.stderr.write("Exiting without doing anything due to --only-on-ci\n")
+        sys.exit()
+    metadata = read_serialized_data(args.path)
+    authors = metadata.get("authors", [])
+    if args.shuffle:
+        sys.stderr.write("Shuffling metadata.authors\n")
+        seed = get_head_commit()
+        shuffle(authors, seed=seed)
+    dump_yaml(metadata, args.path)


### PR DESCRIPTION
See discussion in https://github.com/manubot/manubot/pull/214

uses commit hash as random seed