### PR TITLE
[WIP] Restructure and rewrite of structure and function predictions

### DIFF
--- a/content/04.study.md
+++ b/content/04.study.md
@@ -281,30 +281,31 @@ Though the results are preliminary and still based on a validation set rather th
 Excitingly, these tools seem to show that RNNs can accurately align sequences and predict bulges, mismatches, and wobble base pairing without requiring the user to input secondary structure predictions or thermodynamic calculations.
 Further incremental advances in deep learning for miRNA and target prediction will likely be sufficient to meet the current needs of systems biologists and other researchers who use prediction tools mainly to nominate candidates that are then tested experimentally.
 
-### Protein secondary and tertiary structure
+### Protein structure and function predictions
 
-Proteins play fundamental roles in almost all biological processes, and understanding their structure is critical for basic biology and drug development.
-UniProt currently has about 94 million protein sequences, yet fewer than 100,000 proteins across all species have experimentally-solved structures in Protein Data Bank (PDB).
-As a result, computational structure prediction is essential for a majority of proteins.
-However, this is very challenging, especially when similar solved structures, called templates, are not available in PDB.
-Over the past several decades, many computational methods have been developed to predict aspects of protein structure such as secondary structure, torsion angles, solvent accessibility, inter-residue contact maps, disorder regions, and side-chain packing.
-In recent years, multiple deep learning architectures have been applied, including deep belief networks, LSTMs, CNNs, and deep convolutional neural fields (DeepCNFs)
+Proteins play fundamental roles in almost all biological processes, and understanding their structure and function is critical for biology and drug development alike. Experimental protein structure and function determination are resource intensive and sometimes unfeasible. UniProt's UniParc January 2020 release [@doi:10.1093/nar/gky1049] has about 305 million protein sequences, yet only around 160 thousand proteins across all species have experimentally-solved structures in the Protein Data Bank (PDB) [@doi:10.1093/nar/28.1.235], and around 560 thousand are deposited in Swis-Prot, a sub-collection of proteins with some experimental annotation. As a result, computational protein predictions are essential for a majority of proteins.
+
+Over the past several decades, many computational methods have been developed to predict aspects of protein structure (e.g.: secondary structure [@doi:10.1002/prot.25674; @doi:10.1007/978-3-319-46227-1_1; @doi:10.1038/srep18962; @doi:10.1006/jmbi.1993.1413; @doi:10.1007/978-1-4939-6406-2_6], torsion angles [@doi:10.1186/s12859-017-1834-2; @doi:10.1038/s41586-019-1923-7; @doi:10.1007/978-1-4939-6406-2_6], solvent accessibility [@doi:10.1002/prot.340200303; @doi:10.1007/978-1-4939-6406-2_6], inter-residue contact maps [@doi:10.1093/bioinformatics/bty862; @doi:10.1002/prot.22934; @doi:10.1103/PhysRevE.87.012707], distance maps [@doi: 10.1038/s41586-019-1923-7], disorder regions [@doi:10.1093/bioinformatics/bth195], side-chain packing) and function (e.g. subcellular location [@doi:10.1093/nar/gku396; @doi:10.1093/bioinformatics/btx431], GO annotation [@doi:10.1186/s13059-019-1835-8]). In recent years, multiple deep learning architectures have been applied, including deep belief networks, LSTMs, CNNs, and deep convolutional neural fields (DeepCNFs)
 [@doi:10.1007/978-3-319-46227-1_1; @doi:10.1038/srep18962].
 
-Here we focus on deep learning methods for two representative sub-problems: secondary structure prediction and contact map prediction.
-Secondary structure refers to local conformation of a sequence segment, while a contact map contains information on all residue-residue contacts.
-Secondary structure prediction is a basic problem and an almost essential module of any protein structure prediction package.
-Contact prediction is much more challenging than secondary structure prediction, but it has a much larger impact on tertiary structure prediction.
-In recent years, the accuracy of contact prediction has greatly improved [@doi:10.1371/journal.pcbi.1005324; @doi:10.1093/bioinformatics/btu791; @doi:10.1073/pnas.0805923106; @doi:10.1371/journal.pone.0028766].
+Computational approaches are challenged by experimental data. For structure prediction, most structures cover only regions of protein sequences, many are similar to one another (reducing the amount of diversity, which is needed for machine learning generalization), some lack the resolution to be included in training data, and deposited structures often capture only a snapshot of a protein's state, which may vary during cell activity or be influenced by experimental approaches (e.g. the most widely used experimental approach (X-ray crystallography) requires structures to be determined in non-native environments (aka. not in a cell)). 
 
-One can represent protein secondary structure with three different states (alpha helix, beta strand, and loop regions) or eight finer-grained states.
-Accuracy of a three-state prediction is called Q3, and accuracy of an 8-state prediction is called Q8.
-Several groups [@doi:10.1371/journal.pone.0032235; @doi:10.1109/TCBB.2014.2343960; @doi:10.1038/srep11476] applied deep learning to protein secondary structure prediction but were unable to achieve significant improvement over the *de facto* standard method PSIPRED [@doi:10.1006/jmbi.1999.3091], which uses two shallow feedforward neural networks.
+In-silico methods have nevertheless allowed to shine light in areas where even in-vitro and in-vivo methods at the time couldn't [@doi:10.1006/jmbi.1993.1413 ;@doi:10.1016/j.cell.2012.04.012]. This allowed in-silico methods to elevate from theretical exercises to biological hypothesis generators. Broadly speaking, computational approaches for protein structure prediction from sequence alone can be seen as increasing in level of complexity. The lowest level of such complexity is secondary structure (aka. particular geometric features of folded proteins) [@doi:10.1002/bip.360221211], following are contact maps (aka. a sparse matrix representation of a protein sequence an the interaction of its constituting parts -- amino acids), distance maps (aka. a matrix representation of a protein sequence containing distance measurements amongst amino acids in 3D space), 3D structures (aka. the prediction of spacial coordinates of atoms making a protein), and finally quaternary structure (aka. the interaction between proteins, including the prediction of interfaces (similar to contact prediction) and binary protein-protein interaction prediction). The state of the art methods rely on evolutionary information extracted from multiple sequence alignments (MSAs). Recently, many groups tried to apply DL techniques used in Natural Language Processing (NLP) to learn representations for protein sequences by training Langiuage Models (LMs) on sequence databases [@doi:10.1186/s12859-019-3220-8; @doi:10.1038/s41592-019-0598-1; @doi:10.1101/2020.03.07.982272; @doi:10.1101/622803; @arxiv:1912.05625; arxiv:1906.08230; @doi:10.1101/2020.03.09.983585]. Using a transfer learning approach, the learned embeddings from LMs can be used as input features for supervised models predicting a plethora of downstream tasks, including aspects of structure and function. The LMs can also be directly differentiated with specific downstream tasks [@url:https://papers.nips.cc/paper/9711-generative-models-for-graph-based-protein-design; @doi:10.1016/j.cels.2019.03.006].
+
+#### Secondary structure
+
+Secondary structure refers to local geometric conformations of 3D protein structures. Some aspects of secondary structure are also local to the protein sequence, e.g. alpha-helices, but some, like beta-sheets, are the result of long range interactions of a protein sequence which folds together in 3D space. Secondary structure prediction is a basic problem and an almost essential module of any protein structure prediction package. Secondary structure can be represented in three (alpha helix, beta strand, and loop regions; Q3) or eight finer-grained states (Q8) [@doi:10.1002/bip.360221211] .
+
+Earlier attampts of applying deep learning to secondary structure prediction [@doi:10.1371/journal.pone.0032235; @doi:10.1109/TCBB.2014.2343960; @doi:10.1038/srep11476] didn't achieve significant improvenets over the widly used and relatively simple PSIPRED [@doi:10.1006/jmbi.1999.3091].
 In 2014, Zhou and Troyanskaya demonstrated that they could improve Q8 accuracy by using a deep supervised and convolutional generative stochastic network [@arxiv:1403.1347].
 In 2016 Wang et al. developed a DeepCNF model that improved Q3 and Q8 accuracy as well as prediction of solvent accessibility and disorder regions [@doi:10.1038/srep18962; @doi:10.1007/978-3-319-46227-1_1].
-DeepCNF achieved a higher Q3 accuracy than the standard maintained by PSIPRED for more than 10 years.
-This improvement may be mainly due to the ability of convolutional neural fields to capture long-range sequential information, which is important for beta strand prediction.
-Nevertheless, the improvements in secondary structure prediction from DeepCNF are unlikely to result in a commensurate improvement in tertiary structure prediction since secondary structure mainly reflects coarse-grained local conformation of a protein structure.
+Following these successes, recently proposed methods achieve significantly better results than PSIPRED using Deep Learning architectures, with significantly better DL methods today being NetSurfP-2.0 [@doi:10.1002/prot.25674] and Porter 5 [@doi:10.1038/s41598-019-48786-x].
+
+The improvement obtained by these methods may be mainly due to the ability of convolutional neural fields to capture long-range information. Top methods still heavily rely on the creation of profiles from Multiple Sequence Alignments (MSAs). Models relying on LMs have yet to reach the accuracy of evolutionary based methods, but are able to deliver results for proteins for which MSAs can't be computed and in general execute at a fracion of the time with respect to evolutionary based approaches [@doi:10.1186/s12859-019-3220-8].
+
+
+#### Contact and distance maps
+Contact prediction is much more challenging than secondary structure prediction, but provides much more information for 3D structure prediction. Contact maps can broadly speaking be seen as distance maps with a specific distance cutoff applied. In recent years, the accuracy of contact prediction has greatly improved [@doi:10.1371/journal.pcbi.1005324; @doi:10.1093/bioinformatics/btu791; @doi:10.1073/pnas.0805923106; @doi:10.1371/journal.pone.0028766].
 
 Protein contact prediction and contact-assisted folding (i.e. folding proteins using predicted contacts as restraints) represents a promising new direction for
 *ab initio* folding of proteins without good templates in PDB.
@@ -313,40 +314,23 @@ By combining co-evolution information with a few other protein features, shallow
 In recent years, deeper architectures have been explored for contact prediction, such as CMAPpro [@doi:10.1093/bioinformatics/bts475], DNCON [@doi:10.1093/bioinformatics/bts598] and PConsC [@doi:10.1371/journal.pcbi.1003889].
 However, blindly tested in the well-known CASP competitions, these methods did not show any advantage over MetaPSICOV [@doi:10.1093/bioinformatics/btu791].
 
-Recently, Wang et al. proposed the deep learning method RaptorX-Contact [@doi:10.1371/journal.pcbi.1005324], which significantly improves contact prediction over MetaPSICOV and pure co-evolution methods, especially for proteins without many sequence homologs. It employs a network architecture formed by one 1D residual neural network and one 2D residual neural network.
-Blindly tested in the latest CASP competition (i.e. CASP12 [@url:http://www.predictioncenter.org/casp12/rrc_avrg_results.cgi]), RaptorX-Contact ranked first in F₁ score on free-modeling targets as well as the whole set of targets.
-In CAMEO (which can be interpreted as a fully-automated CASP) [@url:https://www.cameo3d.org], its predicted contacts were also able to fold proteins with a novel fold and only 65--330 sequence homologs.
-This technique also worked well on membrane proteins even when trained on non-membrane proteins [@arxiv:1704.07207].
-RaptorX-Contact performed better mainly due to introduction of residual neural networks and exploitation of contact occurrence patterns by simultaneously predicting all the contacts in a single protein.
+RaptorX-Contact [@doi:10.1371/journal.pcbi.1005324] significantly improved contact prediction over MetaPSICOV and pure co-evolution methods, especially for proteins without many sequence homologs. It employed a network architecture formed by one 1D residual neural network and one 2D residual neural network. Blindly tested in the latest Critical Assesment of Structure Prediction (CASP) competition (i.e. CASP12 [@url:http://www.predictioncenter.org/casp12/rrc_avrg_results.cgi]), RaptorX-Contact ranked first in F₁ score on free-modeling targets as well as the whole set of targets. In CAMEO (which can be interpreted as a fully-automated CASP) [@url:https://www.cameo3d.org], its predicted contacts were also able to fold proteins with a novel fold and only 65--330 sequence homologs. This technique also worked well on membrane proteins even when trained on non-membrane proteins [@arxiv:1704.07207]. RaptorX-Contact performed better mainly due to introduction of residual neural networks and exploitation of contact occurrence patterns by simultaneously predicting all the contacts in a single protein.
+
+Most methods until late 2018 relied on just one distance threshold, simply defined by the ideal contact distance, to produce contact maps for 3D structure prediction. Recent seminal work presented at the 13 edition of CASP combined multiple distance cutoffs together with torsion prediction and a new folding pipeline to achieve state of the art results [@doi:10.1038/s41586-019-1923-7].
 
 Taken together, *ab initio* folding is becoming much easier with the advent of direct evolutionary coupling analysis and deep learning techniques.
-We expect further improvements in contact prediction for proteins with fewer than 1000 homologs by studying new deep network architectures.
-The deep learning methods summarized above also apply to interfacial contact prediction for protein complexes but may be less effective since on average protein complexes have fewer sequence homologs.
-Beyond secondary structure and contact maps, we anticipate increased attention to predicting 3D protein structure directly from amino acid sequence and single residue evolutionary information [@doi:10.1101/265231].
 
-### Structure determination and cryo-electron microscopy
+#### 3D structure from sequence alone
 
-Complementing computational prediction approaches, cryo-electron microscopy (cryo-EM) allows near-atomic resolution determination of protein models by comparing individual electron micrographs [@doi:10.1016/j.cell.2015.03.049].
-Detailed structures require tens of thousands of protein images [@doi:10.1016/j.cell.2015.03.050].
-Technological development has increased the throughput of image capture.
-New hardware, such as direct electron detectors, has made large-scale image production practical, while new software has focused on rapid, automated image processing.
+- Most methods use contact maps and fold
+- Some methods directly learn how to fold [@url:https://papers.nips.cc/paper/9711-generative-models-for-graph-based-protein-design; @doi:10.1016/j.cels.2019.03.006]
 
-Some components of cryo-EM image processing remain difficult to automate.
-For instance, in particle picking, micrographs are scanned to identify individual molecular images that will be used in structure refinement.
-In typical applications, hundreds of thousands of particles are necessary to determine a structure to near atomic resolution, making manual selection impractical [@doi:10.1016/j.cell.2015.03.050].
-Typical selection approaches are semi-supervised; a user will select several particles manually, and these selections will be used to train a classifier [@doi:10.1016/j.jsb.2006.04.006; @doi:10.1016/j.jsb.2014.11.010].
-Now CNNs are being used to select particles in tools like DeepPicker [@doi:10.1016/j.jsb.2016.07.006] and DeepEM [@doi:10.1186/s12859-017-1757-y].
-In addition to addressing shortcomings from manual selection, such as selection bias and poor discrimination of low-contrast images, these approaches also provide a means of full automation.
-DeepPicker can be trained by reference particles from other experiments with structurally unrelated macromolecules, allowing for fully automated application to new samples.
+#### Quaternary structure and protein-protein interactions
 
-Downstream of particle picking, deep learning is being applied to other aspects of cryo-EM image processing.
-Statistical manifold learning has been implemented in the software package ROME to classify selected particles and elucidate the different conformations of the subject molecule necessary for accurate 3D structures [@doi:10.1371/journal.pone.0182130].
-These recent tools highlight the general applicability of deep learning approaches for image processing to increase the throughput of high-resolution cryo-EM.
-
-### Protein-protein interactions
+The deep learning methods summarized in [Contact and distance maps](#contact-and-distance-maps) also apply to quaternary structure prediction (aka. the prediction of contacts for interacting proteins), but may be less effective since on average protein complexes have fewer sequence homologs and there is less availability of experimental data on structures of interacting proteins.
 
 Protein-protein interactions (PPIs) are highly specific and non-accidental physical contacts between proteins, which occur for purposes other than generic protein production or degradation [@doi:10.1371/journal.pcbi.1000807].
-Abundant interaction data have been generated in-part thanks to advances in high-throughput screening methods, such as yeast two-hybrid and affinity-purification with mass spectrometry.
+Abundant interaction data have been generated in-part thanks to advances in high-throughput screening methods, such as yeast two-hybrid and affinity-purification with mass spectrometry [@doi:10.1093/nar/gkw985; @doi:10.1093/database/baz005].
 However, because many PPIs are transient or dependent on biological context, high-throughput methods can fail to capture a number of interactions.
 The imperfections and costs associated with many experimental PPI screening methods have motivated an interest in high-throughput computational prediction.
 
@@ -368,6 +352,25 @@ The authors evaluated the performance of this method with several classifiers an
 
 Because many studies used predefined higher-level features, one of the benefits of deep learning---automatic feature extraction---is not fully leveraged.
 More work is needed to determine the best ways to represent raw protein sequence information so that the full benefits of deep learning as an automatic feature extractor can be realized.
+
+### Structure determination and cryo-electron microscopy
+
+Complementing computational prediction approaches, cryo-electron microscopy (cryo-EM) allows near-atomic resolution determination of protein models by comparing individual electron micrographs [@doi:10.1016/j.cell.2015.03.049].
+Detailed structures require tens of thousands of protein images [@doi:10.1016/j.cell.2015.03.050].
+Technological development has increased the throughput of image capture.
+New hardware, such as direct electron detectors, has made large-scale image production practical, while new software has focused on rapid, automated image processing.
+
+Some components of cryo-EM image processing remain difficult to automate.
+For instance, in particle picking, micrographs are scanned to identify individual molecular images that will be used in structure refinement.
+In typical applications, hundreds of thousands of particles are necessary to determine a structure to near atomic resolution, making manual selection impractical [@doi:10.1016/j.cell.2015.03.050].
+Typical selection approaches are semi-supervised; a user will select several particles manually, and these selections will be used to train a classifier [@doi:10.1016/j.jsb.2006.04.006; @doi:10.1016/j.jsb.2014.11.010].
+Now CNNs are being used to select particles in tools like DeepPicker [@doi:10.1016/j.jsb.2016.07.006] and DeepEM [@doi:10.1186/s12859-017-1757-y].
+In addition to addressing shortcomings from manual selection, such as selection bias and poor discrimination of low-contrast images, these approaches also provide a means of full automation.
+DeepPicker can be trained by reference particles from other experiments with structurally unrelated macromolecules, allowing for fully automated application to new samples.
+
+Downstream of particle picking, deep learning is being applied to other aspects of cryo-EM image processing.
+Statistical manifold learning has been implemented in the software package ROME to classify selected particles and elucidate the different conformations of the subject molecule necessary for accurate 3D structures [@doi:10.1371/journal.pone.0182130].
+These recent tools highlight the general applicability of deep learning approaches for image processing to increase the throughput of high-resolution cryo-EM.
 
 ### MHC-peptide binding
 


### PR DESCRIPTION
Please: consider this a draft to see the direction I'm taking. Help would be very welcome!

While writing, I noticed that the restructuring that was needed was more extensive than I had originally intended & stated in the #1000 

- I'm happy with the general introduction ("Protein structure and function predictions")
- I'm happy with "Secondary structure"
- "Contact and distance maps" seems also quite alright to me.
- "3D structure from sequence alone" is intended as a short section mentioning that most methods use contact/distance maps to fold proteins, but some newer methods (see in manuscript) try to directly go from sequence to structure (in an end-to-end fashion). I'm not too well written in this to have the confidence to write it yet, so I'm asking a colleague who does know
- "Quaternary structure and protein-protein interactions" I haven't really touched on yet, but also here: I might as two colleagues to look at this, they work in exactly this
- I would like to add another section on function prediction where I'd mention subcellular localization & GO annotation prediction (these could actually be 2 or more sections, but I want to keep it easy for now).


REF #1000